### PR TITLE
Document how Haskell receives data from JavaScript

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -40,6 +40,7 @@ let
       niv
       python310
       yarn
+      nodejs
     ];
   };
 

--- a/fido/Crypto/Fido2/Protocol.hs
+++ b/fido/Crypto/Fido2/Protocol.hs
@@ -108,6 +108,26 @@ newtype Challenge = Challenge URLEncodedBase64
 newChallenge :: MonadRandom m => m Challenge
 newChallenge = Challenge . URLEncodedBase64 <$> Random.getRandomBytes 16
 
+{-
+This is the top-level received from the JavaScript side of the Webauthn client.
+The corresponding object in JavaScript is https://w3c.github.io/webauthn/#iface-pkcredential
+However it has been transformed into JSON using https://github.com/github/webauthn-json,
+whose schema uses base64url encoding for raw bytes, indicated by `"convert"`.
+The current JSON schema version defined by webauthn-json is 0.5.7
+TODO: Ensure that the Haskell datatype is always lined up with the version from webauthn-json
+
+This type is used for both registration (attestation) and login (assertion), and differs in these ways depending on that:
+- Registration:
+  - Used for https://w3c.github.io/webauthn/#sctn-registering-a-new-credential
+  - JavaScript client method called is https://w3c.github.io/webappsec-credential-management/#dom-credentialscontainer-create
+  - The response type corresponds to https://w3c.github.io/webauthn/#authenticatorattestationresponse
+  - webauthn-json's JSON schema for it can be gotten with `npx @github/webauthn-json schema | jq '.publicKeyCredentialWithAttestation'`
+- Login:
+  - Used for https://w3c.github.io/webauthn/#sctn-verifying-assertion
+  - JavaScript client method called is https://w3c.github.io/webappsec-credential-management/#dom-credentialscontainer-get
+  - The response type corresponds to https://w3c.github.io/webauthn/#authenticatorassertionresponse
+  - webauthn-json's JSON schema for it can be gotten with `npx @github/webauthn-json schema | jq '.publicKeyCredentialWithAssertion'`
+-}
 data PublicKeyCredential response = PublicKeyCredential
   { id :: Text,
     rawId :: CredentialId,


### PR DESCRIPTION
May be moved or changed in the future, just documenting the current
state for development.

For convenience, here are the schemas for attestation and assertion at version 0.5.7 of webauthn-json (only the `response` part differs, as it should, since the base object is shared)
- Attestation:
  ```json
  {
    "type": {
      "required": true,
      "schema": "copy"
    },
    "id": {
      "required": true,
      "schema": "copy"
    },
    "rawId": {
      "required": true,
      "schema": "convert"
    },
    "response": {
      "required": true,
      "schema": {
        "clientDataJSON": {
          "required": true,
          "schema": "convert"
        },
        "attestationObject": {
          "required": true,
          "schema": "convert"
        }
      }
    },
    "clientExtensionResults": {
      "required": true,
      "schema": {
        "appid": {
          "required": false,
          "schema": "copy"
        },
        "appidExclude": {
          "required": false,
          "schema": "copy"
        },
        "credProps": {
          "required": false,
          "schema": "copy"
        }
      }
    }
  }
  ```
- Assertion:
  ```json
  {
    "type": {
      "required": true,
      "schema": "copy"
    },
    "id": {
      "required": true,
      "schema": "copy"
    },
    "rawId": {
      "required": true,
      "schema": "convert"
    },
    "response": {
      "required": true,
      "schema": {
        "clientDataJSON": {
          "required": true,
          "schema": "convert"
        },
        "authenticatorData": {
          "required": true,
          "schema": "convert"
        },
        "signature": {
          "required": true,
          "schema": "convert"
        },
        "userHandle": {
          "required": true,
          "schema": "convert"
        }
      }
    },
    "clientExtensionResults": {
      "required": true,
      "schema": {
        "appid": {
          "required": false,
          "schema": "copy"
        },
        "appidExclude": {
          "required": false,
          "schema": "copy"
        },
        "credProps": {
          "required": false,
          "schema": "copy"
        }
      }
    }
  }
  ```