### PR TITLE
Upgrade to latest haskell.nix and ghc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,26 +12,16 @@ jobs:
         - macos-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v8
-    - uses: cachix/cachix-action@v6
+    - uses: cachix/install-nix-action@v14
       with:
-        name: haskell-fido2
-        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        extra_nix_config: |
+          trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          substituters = https://hydra.iohk.io https://cache.nixos.org/
 
     - name: "Stylecheck"
       run: |
         nix-shell --pure --command ./bin/autoformat.sh
         git diff --exit-code
 
-    - name: "Make sure nix files are up to date. Run `cabal2nix . > fido2.nix` if this step failed"
-      run: |
-        nix-shell --pure --packages cabal2nix --command "cabal2nix . > /tmp/fido2.nix.new"
-        git diff --no-index fido2.nix /tmp/fido2.nix.new
-
-    - run: nix-build
-    - uses: actions/upload-artifact@v2
-      with:
-        name: Coverage
-        path: "result/share/hpc/vanilla/html/**/*"
-
+    - name: "Build"
+      run: nix-build -A fido2.checks

--- a/default.nix
+++ b/default.nix
@@ -25,7 +25,7 @@ let
       src = ./.;
     };
     # Specify the GHC version to use.
-    compiler-nix-name = "ghc8106";
+    compiler-nix-name = "ghc8107";
   };
 
   deploy = pkgs.writeShellScriptBin "deploy" ''

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "f79152ad394b2a6eb2e39a65df573f1a922658b5",
-        "sha256": "1lbvgspnnxc8mya6ajvf380s59rc58wv0rs3q77fl0cbalac0v23",
+        "rev": "19052d83fda811dd39216e3fc197c980abd037fd",
+        "sha256": "17piis4a66a5x8l4xa6l5bwh02ap2f24hlxd389q9xlmvqrv902x",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/f79152ad394b2a6eb2e39a65df573f1a922658b5.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/19052d83fda811dd39216e3fc197c980abd037fd.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
A bug we previously experienced has been resolved.

This updates the used GHC version to 8.10.7