### PR TITLE
Document all error messages

### DIFF
--- a/fido/Crypto/Fido2/Attestation.hs
+++ b/fido/Crypto/Fido2/Attestation.hs
@@ -8,7 +8,7 @@ import Crypto.Fido2.Attestation.Packed as Packed (verify)
 import Crypto.Fido2.Error
   ( AttestationError
       ( AttestationCommonError,
-        AttestationCredentialDataMissing
+        CredentialDataMissing
       ),
     CommonError
       ( ChallengeMismatch,
@@ -186,5 +186,5 @@ validateAttStmt :: AttestationFormat -> AuthenticatorData -> Digest SHA256 -> Ei
 validateAttStmt FormatNone AuthenticatorData {attestedCredentialData} _ =
   case attestedCredentialData of
     Just attestedCredentialData -> pure attestedCredentialData
-    Nothing -> Left AttestationCredentialDataMissing
+    Nothing -> Left CredentialDataMissing
 validateAttStmt (FormatPacked stmt) authData clientDataHash = Packed.verify stmt authData clientDataHash

--- a/fido/Crypto/Fido2/Error.hs
+++ b/fido/Crypto/Fido2/Error.hs
@@ -8,56 +8,88 @@ import Data.Binary.Get (ByteOffset)
 import Data.ByteString.Lazy (ByteString)
 import Data.Text (Text)
 
+-- | Errors that are shared between attestation and assertion
 data CommonError
-  = InvalidWebauthnType
-  | ChallengeMismatch
-  | ChallengeMissing
-  | CredentialMismatch
-  | RpOriginMismatch
-  | RpIdHashMismatch
-  | UserNotPresent
-  | UserNotVerified
-  | InvalidSignature
-  | ExtensionsInvalid
-  | CryptoFailure CryptoError
-  | CryptoCurveUnsupported
-  | CryptoAlgorithmUnsupported
-  | CryptoKeyTypeUnsupported
-  | DecodingError DecodingError
+  = -- | The given attestation type did not match the correct method
+    InvalidWebauthnType
+  | -- | The returned challenge does not match the desired one
+    ChallengeMismatch
+  | -- | The returned credential cannot be found in the known credentials
+    CredentialMismatch
+  | -- | The returned origin does not match the relying party's origin
+    RpOriginMismatch
+  | -- | The hash of the relying party id does not match the has in the returned authentication data
+    RpIdHashMismatch
+  | -- | The userpresent bit in the authdata was not set
+    UserNotPresent
+  | -- | The userverified bit in the authdata was not set
+    UserNotVerified
+  | -- | The provided signature is not valid over the authData and hash
+    InvalidSignature
+  | -- | An wrapper around the CryptoError type from the cryptonite library
+    CryptoFailure CryptoError
+  | -- | The desired curve is not supported by this implementation or by the fido2 specification
+    -- TODO: Use
+    CryptoCurveUnsupported
+  | -- | The desired algorithm is not supported by this implementation or by the fido2 specification
+    -- TODO: Use
+    CryptoAlgorithmUnsupported
+  | -- | The desired key type is not supported by this implementation or by the fido2 specification
+    -- TODO: Use
+    CryptoKeyTypeUnsupported
+  | -- | Any part of the data could not be decoded for the provided reason
+    DecodingError DecodingError
   deriving (Show, Eq)
 
+-- | Any error that occurs during decoding
 data DecodingError
-  = Base64Failure
-  | CBORFailure CBOR.DeserialiseFailure
-  | JSONFailure Aeson.JSONPath String
-  | BinaryFailure (ByteString, ByteOffset, String)
-  | FormatUnsupported Text
+  = -- | The base64 encoded data could not be decoded
+    Base64Failure
+  | -- | The CBOR encoded data could not be decoded for the provided reason
+    CBORFailure CBOR.DeserialiseFailure
+  | -- | The JSON data could not be parsed
+    JSONFailure Aeson.JSONPath String
+  | -- | The binary data could not be decoded
+    BinaryFailure (ByteString, ByteOffset, String)
+  | -- | The desired attestation format is not supported
+    FormatUnsupported Text
   deriving (Show, Eq)
 
+-- | Any error that occurs during assertion
 newtype AssertionError
-  = AssertionCommonError CommonError
+  = -- | A common error occured
+    -- TODO: Currently, assertion only results in common errors, although this might not strictly be true.
+    -- A re-evaluation is needed after attestation has been fully implemented
+    AssertionCommonError CommonError
   deriving (Show, Eq)
 
+-- | Any error that occurs during attestation
 data AttestationError
-  = CredentialDataMissing
-  | StatementMissing Text
-  | StatementInvalidSignature
-  | StatementAlgorithmMismatch
+  = -- | No attested credential was found
+    CredentialDataMissing
+  | -- | The algorithm in the attestation statement differs from the algorithm
+    --   corresponding to the public key in the authentication data
+    StatementAlgorithmMismatch
   | -- | The attestation format was none, but attestation data was still present.
     StatementPresentForNone
-  | AttestationCredentialDataMissing
-  | AttestationCredentialAAGUIDMissing
+  | -- | No AAGUID was found in the attested credential data
+    AttestationCredentialAAGUIDMissing
   | -- | The certificate's trust could not be established. This could be because it was unsigned,
     -- or the signed certificate was not found in the certificate store.
     TrustFailure
-  | CertificateAAGUIDMismatch
+  | -- | The AAGUID of the credential data differs from the AAGUID in the certificate of the statement
+    CertificateAAGUIDMismatch
   | -- | The specified TPM field does not match
     TPMMismatch Text
   | -- | The specified TPM field is invalid
     TPMInvalid Text
   | -- | https://www.w3.org/TR/webauthn-2/#sctn-packed-attestation-cert-requirements
     CertificateRequirementsUnmet
-  | CertiticatePublicKeyInvalid
-  | ASN1Error ASN1Error
-  | AttestationCommonError CommonError
+  | -- | The certificate could not be parsed in a way to retrieve the public key
+    -- TODO: Maybe a different name?
+    CertiticatePublicKeyInvalid
+  | -- | The ASN1 decoding failed for the provided reason
+    ASN1Error ASN1Error
+  | -- | A common error occured during attestation
+    AttestationCommonError CommonError
   deriving (Show, Eq)

--- a/fido/Crypto/Fido2/Signature.hs
+++ b/fido/Crypto/Fido2/Signature.hs
@@ -1,6 +1,9 @@
 module Crypto.Fido2.Signature (verifyX509Sig) where
 
-import Crypto.Fido2.Error (AttestationError (StatementInvalidSignature))
+import Crypto.Fido2.Error
+  ( AttestationError (AttestationCommonError),
+    CommonError (InvalidSignature),
+  )
 import Data.ByteString (ByteString)
 import qualified Data.X509 as X509
 import qualified Data.X509.Validation as X509
@@ -9,4 +12,4 @@ verifyX509Sig :: X509.SignatureALG -> X509.PubKey -> ByteString -> ByteString ->
 verifyX509Sig sigType pub dat sig = case X509.verifySignature sigType pub dat sig of
   X509.SignaturePass -> pure ()
   -- TODO: Pass along SignatureFailure to error
-  X509.SignatureFailed _ -> Left StatementInvalidSignature
+  X509.SignatureFailed _ -> Left $ AttestationCommonError InvalidSignature

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -19,7 +19,7 @@ import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Maybe (MaybeT (MaybeT, runMaybeT))
 import qualified Crypto.Fido2.Assertion as Assertion
 import Crypto.Fido2.Attestation (verifyAttestationResponse)
-import Crypto.Fido2.Error (Error)
+import Crypto.Fido2.Error (AttestationError)
 import qualified Crypto.Fido2.Protocol as Fido2
 import qualified Crypto.Fido2.PublicKey as Fido2
 import Data.Aeson (FromJSON)
@@ -186,7 +186,7 @@ mkCredentialDescriptor credentialId =
 data RegistrationResult
   = Success
   | AlreadyRegistered
-  | AttestationError Error
+  | AttestationError AttestationError
   deriving (Eq, Show)
 
 handleError :: Show e => Either e a -> Scotty.ActionM a

--- a/tests/AttestationSpec.hs
+++ b/tests/AttestationSpec.hs
@@ -192,7 +192,7 @@ spec = do
                             }
                       }
                in case Fido2.verifyAttestationResponse origin rp challenge Fido2.UserVerificationPreferred resp of
-                    Left x -> x === Fido2.AttestationCredentialDataMissing
+                    Left x -> x === Fido2.CredentialDataMissing
       -- Kinda lame. We know that show is total as it's derived
       it
         "Can show Error"

--- a/tests/Spec/Types.hs
+++ b/tests/Spec/Types.hs
@@ -40,12 +40,10 @@ instance Arbitrary Fido2.CommonError where
     elements
       [ Fido2.InvalidWebauthnType,
         Fido2.ChallengeMismatch,
-        Fido2.ChallengeMissing,
         Fido2.RpOriginMismatch,
         Fido2.RpIdHashMismatch,
         Fido2.UserNotPresent,
         Fido2.UserNotVerified,
-        Fido2.ExtensionsInvalid,
         Fido2.CryptoCurveUnsupported,
         Fido2.CryptoAlgorithmUnsupported,
         Fido2.CryptoKeyTypeUnsupported


### PR DESCRIPTION
Some error messages were removed or renamed as I found that duplicates
existed or that we have no use for them.