### PR TITLE
Tests based on Client emulation

### DIFF
--- a/fido/Crypto/Fido2/Model.hs
+++ b/fido/Crypto/Fido2/Model.hs
@@ -346,7 +346,7 @@ newtype AAGUID = AAGUID {unAAGUID :: BS.ByteString}
 -- and https://www.w3.org/TR/webauthn-2/#dom-publickeycredentialrequestoptions-rpid, but the former
 -- uses DOMString, while the latter uses USVString. Is this a bug in the spec or is there an actual difference?
 newtype RpId = RpId {unRpId :: Text}
-  deriving (Eq, Show)
+  deriving (Eq, Show, Ord)
   deriving newtype (IsString)
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dom-publickeycredentialentity-name)
@@ -375,7 +375,7 @@ newtype RelyingPartyName = RelyingPartyName {unRelyingPartyName :: Text}
 -- A user handle is an opaque [byte sequence](https://infra.spec.whatwg.org/#byte-sequence)
 -- with a maximum size of 64 bytes, and is not meant to be displayed to the user.
 newtype UserHandle = UserHandle {unUserHandle :: BS.ByteString}
-  deriving (Eq, Show)
+  deriving (Eq, Show, Ord)
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#user-handle)
 -- A user handle is an opaque [byte sequence](https://infra.spec.whatwg.org/#byte-sequence)
@@ -423,7 +423,7 @@ newtype UserAccountName = UserAccountName {unUserAccountName :: Text}
 -- identifying a [public key credential](https://www.w3.org/TR/webauthn-2/#public-key-credential-source)
 -- source and its [authentication assertions](https://www.w3.org/TR/webauthn-2/#authentication-assertion).
 newtype CredentialId = CredentialId {unCredentialId :: BS.ByteString}
-  deriving (Eq, Show)
+  deriving (Eq, Show, Ord)
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#sctn-cryptographic-challenges)
 -- This member contains a challenge intended to be used for generating the newly

--- a/fido/Crypto/Fido2/Model.hs
+++ b/fido/Crypto/Fido2/Model.hs
@@ -880,6 +880,14 @@ class
     HashMap Text CBOR.Term ->
     Either (AttStmtDecodingError a) (AttStmt a)
 
+  -- | An encoder for the attestation statement [syntax](https://www.w3.org/TR/webauthn-2/#sctn-attestation-formats).
+  -- The @attStmt@ CBOR map is expected as the result. See
+  -- [Generating an Attestation Object](https://www.w3.org/TR/webauthn-2/#sctn-generating-an-attestation-object)
+  asfEncode ::
+    a ->
+    AttStmt a ->
+    CBOR.Term
+
 -- | An arbitrary [attestation statement format](https://www.w3.org/TR/webauthn-2/#sctn-attestation-formats).
 -- In contrast to 'DecodingAttestationStatementFormat', this type can be put into a list.
 -- This is used for 'mkSupportedAttestationStatementFormats'

--- a/fido/Crypto/Fido2/Model/JavaScript/Decoding.hs
+++ b/fido/Crypto/Fido2/Model/JavaScript/Decoding.hs
@@ -22,6 +22,8 @@ module Crypto.Fido2.Model.JavaScript.Decoding
     decodeRequestedPublicKeyCredential,
     decodePublicKeyCredentialCreationOptions,
     decodePublicKeyCredentialRequestOptions,
+    decodeCreateCollectedClientData,
+    decodeGetCollectedClientData,
   )
 where
 
@@ -470,3 +472,11 @@ decodePublicKeyCredentialRequestOptions ::
   JS.PublicKeyCredentialRequestOptions ->
   Either DecodingError (M.PublicKeyCredentialOptions 'M.Get)
 decodePublicKeyCredentialRequestOptions = decode
+
+-- | [(spec)](https://www.w3.org/TR/webauthn-2/#dictionary-client-data)
+decodeCreateCollectedClientData :: JS.ArrayBuffer -> Either DecodingError (M.CollectedClientData 'M.Create)
+decodeCreateCollectedClientData = decode
+
+-- | [(spec)](https://www.w3.org/TR/webauthn-2/#dictionary-client-data)
+decodeGetCollectedClientData :: JS.ArrayBuffer -> Either DecodingError (M.CollectedClientData 'M.Get)
+decodeGetCollectedClientData = decode

--- a/fido/Crypto/Fido2/Model/JavaScript/Decoding.hs
+++ b/fido/Crypto/Fido2/Model/JavaScript/Decoding.hs
@@ -40,6 +40,7 @@ import Crypto.Fido2.Model
 import qualified Crypto.Fido2.Model as M
 import qualified Crypto.Fido2.Model.JavaScript as JS
 import Crypto.Fido2.Model.JavaScript.Types (Convert (JS))
+import qualified Crypto.Fido2.Model.JavaScript.Types as JS
 import Crypto.Fido2.Model.WebauthnType (SWebauthnType (SCreate, SGet), SingI (sing))
 import Crypto.Fido2.PublicKey (decodePublicKey)
 import qualified Crypto.Fido2.PublicKey as PublicKey
@@ -58,8 +59,6 @@ import Data.Maybe (catMaybes, fromJust, mapMaybe)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text.Encoding as Text
-import qualified Deriving.Aeson as Aeson
-import GHC.Generics (Generic)
 
 -- | Decoding errors that can only occur when decoding a
 -- 'JS.CreatedPublicKeyCredential' result with 'decodeCreatedPublicKeyCredential'
@@ -218,29 +217,10 @@ instance Decode M.AuthenticationExtensionsClientOutputs where
   -- TODO: Implement extension support
   decode _ = pure M.AuthenticationExtensionsClientOutputs {}
 
--- | [(spec)](https://www.w3.org/TR/webauthn-2/#dictionary-client-data)
--- Intermediate type used to extract the JSON structure stored in the
--- CBOR-encoded [clientDataJSON](https://www.w3.org/TR/webauthn-2/#dom-authenticatorresponse-clientdatajson).
-data ClientDataJSON = ClientDataJSON
-  { typ :: JS.DOMString,
-    challenge :: JS.DOMString,
-    origin :: JS.DOMString,
-    crossOrigin :: Maybe Bool
-    -- TODO
-    -- tokenBinding :: Maybe TokenBinding
-  }
-  deriving (Generic)
-  -- Note: Encoding can NOT be derived automatically, and most likely not even
-  -- be provided correctly with the Aeson.ToJSON class, because it is only a
-  -- JSON-_compatible_ encoding, but it also contains some extra structure
-  -- allowing for verification without a full JSON parser
-  -- See <https://www.w3.org/TR/webauthn-2/#clientdatajson-serialization>
-  deriving (Aeson.FromJSON) via Aeson.CustomJSON '[Aeson.OmitNothingFields, Aeson.FieldLabelModifier (Aeson.Rename "typ" "type")] ClientDataJSON
-
 instance SingI t => Decode (M.CollectedClientData t) where
   decode (JS.URLEncodedBase64 bytes) = do
     -- https://www.w3.org/TR/webauthn-2/#collectedclientdata-json-compatible-serialization-of-client-data
-    ClientDataJSON {..} <- first DecodingErrorClientDataJSON $ Aeson.eitherDecodeStrict bytes
+    JS.ClientDataJSON {..} <- first DecodingErrorClientDataJSON $ Aeson.eitherDecodeStrict bytes
     -- [(spec)](https://www.w3.org/TR/webauthn-2/#dom-collectedclientdata-challenge)
     -- This member contains the base64url encoding of the challenge provided by the
     -- [Relying Party](https://www.w3.org/TR/webauthn-2/#relying-party). See the

--- a/fido/Crypto/Fido2/Model/JavaScript/Types.hs
+++ b/fido/Crypto/Fido2/Model/JavaScript/Types.hs
@@ -4,6 +4,7 @@
 
 module Crypto.Fido2.Model.JavaScript.Types
   ( Convert (..),
+    ClientDataJSON (..),
   )
 where
 
@@ -13,6 +14,32 @@ import qualified Crypto.Fido2.PublicKey as PublicKey
 import qualified Data.Aeson as Aeson
 import Data.Map (Map)
 import Data.Text (Text)
+import qualified Deriving.Aeson as Aeson
+import GHC.Generics (Generic)
+
+-- | [(spec)](https://www.w3.org/TR/webauthn-2/#dictionary-client-data)
+-- Intermediate type used to extract the JSON structure stored in the
+-- CBOR-encoded [clientDataJSON](https://www.w3.org/TR/webauthn-2/#dom-authenticatorresponse-clientdatajson).
+-- NOTE: Do not rely on the ToJSON instance of this type, it is not implemented according to spec.
+data ClientDataJSON = ClientDataJSON
+  { typ :: JS.DOMString,
+    challenge :: JS.DOMString,
+    origin :: JS.DOMString,
+    crossOrigin :: Maybe Bool
+    -- TODO
+    -- tokenBinding :: Maybe TokenBinding
+  }
+  deriving (Generic)
+  -- Note: Encoding can NOT be derived automatically, and most likely not even
+  -- be provided correctly with the Aeson.ToJSON class, because it is only a
+  -- JSON-_compatible_ encoding, but it also contains some extra structure
+  -- allowing for verification without a full JSON parser
+  -- See <https://www.w3.org/TR/webauthn-2/#clientdatajson-serialization>
+  -- TODO/FIXME: As described above the ToJSON instance should not be derived,
+  -- but implemented manually using the description provided in the specification.
+  -- For now the ToJSON instance is only used for tests so it suffices, but
+  -- library users should not rely on it.
+  deriving (Aeson.FromJSON, Aeson.ToJSON) via Aeson.CustomJSON '[Aeson.OmitNothingFields, Aeson.FieldLabelModifier (Aeson.Rename "typ" "type")] ClientDataJSON
 
 -- | @'Convert' hs@ indicates that the Haskell-specific type @hs@ has a more
 -- general JavaScript-specific type associated with it, which can be accessed with 'JS'.

--- a/fido/Crypto/Fido2/Operations/Attestation/None.hs
+++ b/fido/Crypto/Fido2/Operations/Attestation/None.hs
@@ -6,6 +6,7 @@ module Crypto.Fido2.Operations.Attestation.None
   )
 where
 
+import qualified Codec.CBOR.Term as CBOR
 import qualified Crypto.Fido2.Model as M
 import qualified Data.Text as Text
 import Data.Void (Void)
@@ -21,6 +22,7 @@ instance M.AttestationStatementFormat Format where
 
   type AttStmtDecodingError Format = Void
   asfDecode _ _ = Right ()
+  asfEncode _ _ = CBOR.TMap []
 
   type AttStmtVerificationError Format = Void
   asfVerify _ _ _ _ = Right M.AttestationTypeNone

--- a/fido/Crypto/Fido2/Operations/Attestation/Packed.hs
+++ b/fido/Crypto/Fido2/Operations/Attestation/Packed.hs
@@ -16,7 +16,7 @@ import qualified Codec.CBOR.Term as CBOR
 import Control.Exception (Exception)
 import Control.Monad (forM, unless, when)
 import qualified Crypto.Fido2.Model as M
-import Crypto.Fido2.PublicKey (COSEAlgorithmIdentifier, toAlg, toCOSEAlgorithmIdentifier)
+import Crypto.Fido2.PublicKey (COSEAlgorithmIdentifier, fromAlg, toAlg, toCOSEAlgorithmIdentifier)
 import qualified Crypto.Fido2.PublicKey as PublicKey
 import Data.ASN1.BinaryEncoding (DER (DER))
 import Data.ASN1.Encoding (ASN1Decoding (decodeASN1))
@@ -29,7 +29,7 @@ import qualified Data.ByteString as BS
 import Data.ByteString.Lazy (fromStrict)
 import Data.HashMap.Strict (HashMap, (!?))
 import Data.List (find)
-import Data.List.NonEmpty (NonEmpty ((:|)))
+import Data.List.NonEmpty (NonEmpty ((:|)), toList)
 import qualified Data.List.NonEmpty as NE
 import Data.Maybe (isJust)
 import Data.Text (Text)
@@ -88,6 +88,16 @@ instance M.AttestationStatementFormat Format where
           _ -> Left $ DecodingErrorUnexpectedCBORStructure xs
         pure $ Statement {..}
       _ -> Left $ DecodingErrorUnexpectedCBORStructure xs
+
+  asfEncode _ Statement {alg, sig, x5c} =
+    let encodedx5c = case x5c of
+          Nothing -> []
+          Just certChain -> map (CBOR.TBytes . X509.encodeSignedObject) $ toList certChain
+     in CBOR.TMap
+          [ (CBOR.TString "sig", CBOR.TBytes sig),
+            (CBOR.TString "alg", CBOR.TInt $ fromAlg alg),
+            (CBOR.TString "x5c", CBOR.TList encodedx5c)
+          ]
 
   type AttStmtVerificationError Format = VerificationError
 

--- a/fido/Crypto/Fido2/PublicKey.hs
+++ b/fido/Crypto/Fido2/PublicKey.hs
@@ -12,19 +12,23 @@ module Crypto.Fido2.PublicKey
     verify,
     decodePublicKey,
     decodeCOSEAlgorithmIdentifier,
+    encodePublicKey,
     toAlg,
     toPublicKey,
     toCOSEAlgorithmIdentifier,
     toECDSAKey,
+    fromAlg,
+    toCurveName,
   )
 where
 
 import qualified Codec.CBOR.Decoding as CBOR
+import qualified Codec.CBOR.Encoding as CBOR
 import Control.Monad (unless, when)
 import Crypto.Error (CryptoFailable (CryptoFailed, CryptoPassed))
 import Crypto.Hash (HashAlgorithm)
 import qualified Crypto.Hash.Algorithms as Hash
-import Crypto.Number.Serialize (os2ip)
+import Crypto.Number.Serialize (i2osp, os2ip)
 import qualified Crypto.PubKey.ECC.ECDSA as ECDSA
 import qualified Crypto.PubKey.ECC.Prim as ECC
 import qualified Crypto.PubKey.ECC.Types as ECC
@@ -32,6 +36,7 @@ import qualified Crypto.PubKey.Ed25519 as Ed25519
 import qualified Data.ASN1.BinaryEncoding as ASN1
 import qualified Data.ASN1.Encoding as ASN1
 import qualified Data.ASN1.Prim as ASN1
+import qualified Data.ByteArray as ByteArray
 import Data.ByteString (ByteString)
 import qualified Data.X509 as X509
 import qualified Data.X509.EC as X509
@@ -59,6 +64,8 @@ data KeyType = OKP | ECC
 
 data MapKey = Kty | Alg | Crv | X | Y deriving (Show, Eq)
 
+-- TODO: We could do without this type by going from Cryptonite's NamedCurve
+-- straight to the encoding
 data CurveIdentifier = P256 | P384 | P521
   deriving (Eq)
 
@@ -115,14 +122,6 @@ decodePublicKey = do
       unless (ECC.isPointValid curve point) $ fail "point not on curve"
       toECDSAKey alg (ECDSA.PublicKey curve point)
 
-    mapKeyToInt :: MapKey -> Int
-    mapKeyToInt key = case key of
-      Kty -> 1
-      Alg -> 3
-      Crv -> -1
-      X -> -2
-      Y -> -3
-
     decodeKeyType :: CBOR.Decoder s KeyType
     decodeKeyType = do
       kty <- CBOR.decodeIntCanonical
@@ -142,6 +141,7 @@ decodePublicKey = do
     toCurve P384 = ECC.getCurveByName ECC.SEC_p384r1
     toCurve P521 = ECC.getCurveByName ECC.SEC_p521r1
 
+    -- [(spec)](https://www.iana.org/assignments/cose/cose.xhtml)
     decodeCurveIdentifier :: CBOR.Decoder s CurveIdentifier
     decodeCurveIdentifier = do
       crv <- CBOR.decodeIntCanonical
@@ -156,6 +156,21 @@ decodePublicKey = do
       key' <- CBOR.decodeIntCanonical
       when (mapKeyToInt key /= key') $ fail $ "Expected " ++ show key
 
+toCurveName :: COSEAlgorithmIdentifier -> ECC.CurveName
+toCurveName COSEAlgorithmIdentifierES256 = ECC.SEC_p256r1
+toCurveName COSEAlgorithmIdentifierES384 = ECC.SEC_p384r1
+toCurveName COSEAlgorithmIdentifierES512 = ECC.SEC_p521r1
+toCurveName COSEAlgorithmIdentifierEdDSA = error "EdDSA does not have an associated ECC Curve (Keytype is OKP)"
+
+-- | [(spec)](https://www.iana.org/assignments/cose/cose.xhtml)
+mapKeyToInt :: MapKey -> Int
+mapKeyToInt key = case key of
+  Kty -> 1
+  Alg -> 3
+  Crv -> -1
+  X -> -2
+  Y -> -3
+
 -- All CBOR is encoded using
 -- https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-client-to-authenticator-protocol-v2.0-id-20180227.html#ctap2-canonical-cbor-encoding-form
 
@@ -166,12 +181,71 @@ decodeCOSEAlgorithmIdentifier :: CBOR.Decoder s COSEAlgorithmIdentifier
 decodeCOSEAlgorithmIdentifier =
   toAlg =<< CBOR.decodeIntCanonical
 
+encodePublicKey :: PublicKey -> CBOR.Encoding
+encodePublicKey pk@(ES256PublicKey ecdsaPk) = encodeECDSA (toCOSEAlgorithmIdentifier pk) ecdsaPk
+encodePublicKey pk@(ES384PublicKey ecdsaPk) = encodeECDSA (toCOSEAlgorithmIdentifier pk) ecdsaPk
+encodePublicKey pk@(ES512PublicKey ecdsaPk) = encodeECDSA (toCOSEAlgorithmIdentifier pk) ecdsaPk
+encodePublicKey pk@(Ed25519PublicKey edPk) =
+  CBOR.encodeMapLen 4
+    <> encodeMapKey Kty
+    <> encodeKeyType OKP
+    <> encodeMapKey Alg
+    <> encodeCOSEAlgorithm (toCOSEAlgorithmIdentifier pk)
+    <> encodeMapKey Crv
+    <> CBOR.encodeInt 6
+    <> encodeMapKey X
+    <> CBOR.encodeBytes (ByteArray.convert edPk)
+
+encodeECDSA :: COSEAlgorithmIdentifier -> ECDSA.PublicKey -> CBOR.Encoding
+encodeECDSA ident ECDSA.PublicKey {ECDSA.public_q = ECC.Point x y} =
+  CBOR.encodeMapLen 5
+    <> encodeMapKey Kty
+    <> encodeKeyType ECC
+    <> encodeMapKey Alg
+    <> encodeCOSEAlgorithm ident
+    <> encodeMapKey Crv
+    <> encodeCurve ident
+    <> encodeMapKey X
+    <> CBOR.encodeBytes (i2osp x)
+    <> encodeMapKey Y
+    <> CBOR.encodeBytes (i2osp y)
+encodeECDSA _ ECDSA.PublicKey {ECDSA.public_q = ECC.PointO} = error "Unreachable: Points at infinity are not allowed for the supported curves"
+
+-- | [(spec)](https://www.iana.org/assignments/cose/cose.xhtml)
+encodeKeyType :: KeyType -> CBOR.Encoding
+encodeKeyType OKP = CBOR.encodeInt 1
+encodeKeyType ECC = CBOR.encodeInt 2
+
+encodeMapKey :: MapKey -> CBOR.Encoding
+encodeMapKey = CBOR.encodeInt . mapKeyToInt
+
+-- | [(spec)](https://www.iana.org/assignments/cose/cose.xhtml)
+encodeCOSEAlgorithm :: COSEAlgorithmIdentifier -> CBOR.Encoding
+encodeCOSEAlgorithm COSEAlgorithmIdentifierES256 = CBOR.encodeInt (-7)
+encodeCOSEAlgorithm COSEAlgorithmIdentifierES384 = CBOR.encodeInt (-35)
+encodeCOSEAlgorithm COSEAlgorithmIdentifierES512 = CBOR.encodeInt (-36)
+encodeCOSEAlgorithm COSEAlgorithmIdentifierEdDSA = CBOR.encodeInt (-8)
+
+-- | [(spec)](https://www.iana.org/assignments/cose/cose.xhtml)
+encodeCurve :: COSEAlgorithmIdentifier -> CBOR.Encoding
+encodeCurve COSEAlgorithmIdentifierES256 = CBOR.encodeInt 1
+encodeCurve COSEAlgorithmIdentifierES384 = CBOR.encodeInt 2
+encodeCurve COSEAlgorithmIdentifierES512 = CBOR.encodeInt 3
+encodeCurve COSEAlgorithmIdentifierEdDSA = error "Unreachable: EdDSA identifier does not have a curve encoding associated with it"
+
 toAlg :: (Eq a, Num a, MonadFail f) => a -> f COSEAlgorithmIdentifier
 toAlg (-7) = pure COSEAlgorithmIdentifierES256
 toAlg (-35) = pure COSEAlgorithmIdentifierES384
 toAlg (-36) = pure COSEAlgorithmIdentifierES512
 toAlg (-8) = pure COSEAlgorithmIdentifierEdDSA
 toAlg _ = fail "Unsupported `alg`"
+
+-- | [(spec)](https://www.iana.org/assignments/cose/cose.xhtml)
+fromAlg :: Num a => COSEAlgorithmIdentifier -> a
+fromAlg COSEAlgorithmIdentifierES256 = -7
+fromAlg COSEAlgorithmIdentifierES384 = -35
+fromAlg COSEAlgorithmIdentifierES512 = -36
+fromAlg COSEAlgorithmIdentifierEdDSA = -8
 
 toCOSEAlgorithmIdentifier :: PublicKey -> COSEAlgorithmIdentifier
 toCOSEAlgorithmIdentifier (ES256PublicKey _) = COSEAlgorithmIdentifierES256

--- a/fido2.cabal
+++ b/fido2.cabal
@@ -116,7 +116,8 @@ test-suite tests
     PublicKeySpec,
     MetadataSpec,
     Spec.Types,
-    Spec.Util
+    Spec.Util,
+    Client.PrivateKey,
   build-depends:
     aeson,
     bytestring,

--- a/fido2.cabal
+++ b/fido2.cabal
@@ -117,7 +117,9 @@ test-suite tests
     MetadataSpec,
     Spec.Types,
     Spec.Util,
+    Client,
     Client.PrivateKey,
+    Authenticator
   build-depends:
     aeson,
     bytestring,
@@ -138,4 +140,8 @@ test-suite tests
     mtl,
     x509,
     pem,
-    validation
+    validation,
+    containers,
+    binary,
+    random,
+    base64-bytestring

--- a/tests/Authenticator.hs
+++ b/tests/Authenticator.hs
@@ -1,0 +1,456 @@
+{-# LANGUAGE BinaryLiterals #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Authenticator
+  ( PublicKeyCredentialSource (..),
+    AuthenticatorSignatureCounter (..),
+    Authenticator (..),
+    authenticatorMakeCredential,
+    authenticatorGetAssertion,
+  )
+where
+
+import qualified Client.PrivateKey as PrivateKey
+import qualified Codec.CBOR.Write as CBOR
+import Control.Monad (forM_, when)
+import qualified Crypto.Fido2.Model as M
+import qualified Crypto.Fido2.Operations.Attestation.None as None
+import qualified Crypto.Fido2.PublicKey as PublicKey
+import Crypto.Hash (hash)
+import qualified Crypto.PubKey.ECC.Generate as ECC
+import qualified Crypto.PubKey.ECC.Types as ECC
+import qualified Crypto.PubKey.Ed25519 as Ed25519
+import Crypto.Random (MonadRandom)
+import qualified Crypto.Random as Random
+import Data.Binary.Put (runPut)
+import qualified Data.Binary.Put as Put
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString as BS
+import Data.ByteString.Lazy (toStrict)
+import Data.List (find)
+import qualified Data.Map as Map
+import Data.Maybe (fromJust, fromMaybe, mapMaybe)
+import qualified Data.Set as Set
+import Data.Text.Encoding (encodeUtf8)
+
+-- | [(spec)](https://www.w3.org/TR/webauthn-2/#public-key-credential-source)
+-- A stored credential.
+data PublicKeyCredentialSource = PublicKeyCredentialSource
+  { pkcsId :: M.CredentialId,
+    pkcsPrivateKey :: PrivateKey.PrivateKey,
+    pkcsRpId :: M.RpId,
+    pkcsUserHandle :: Maybe M.UserHandle
+  }
+  deriving (Show)
+
+data AuthenticatorSignatureCounter
+  = Unsupported
+  | Global M.SignatureCounter
+  | PerCredential (Map.Map M.CredentialId M.SignatureCounter)
+  deriving (Show)
+
+-- | The datatype holding all information needed for attestation and assertion
+data Authenticator = AuthenticatorNone
+  -- https://www.w3.org/TR/webauthn-2/#authenticator-credentials-map
+  { aCredentials :: Map.Map (M.RpId, M.UserHandle) PublicKeyCredentialSource,
+    aSignatureCounter :: AuthenticatorSignatureCounter,
+    aSupportedAlgorithms :: Set.Set PublicKey.COSEAlgorithmIdentifier,
+    aAAGUID :: M.AAGUID
+  }
+  deriving (Show)
+
+-- | [(spec)](https://www.w3.org/TR/webauthn-2/#sctn-op-make-cred)
+authenticatorMakeCredential ::
+  (MonadRandom m, MonadFail m) =>
+  -- | authenticator: The stored authenticator data
+  Authenticator ->
+  -- | hash: The hash of the serialized client data, provided by the client.
+  M.ClientDataHash ->
+  -- | rpEntity: The Relying Party's PublicKeyCredentialRpEntity.
+  M.PublicKeyCredentialRpEntity ->
+  -- | userEntity: The user account’s PublicKeyCredentialUserEntity, containing
+  -- the user handle given by the Relying Party.
+  M.PublicKeyCredentialUserEntity ->
+  -- | requireResidentKey: The effective resident key requirement for
+  -- credential creation, a Boolean value determined by the client.
+  -- NOTE: We always provide resident keys
+  Bool ->
+  -- | requireUserPresence: The constant Boolean value true. It is included
+  -- here as a pseudo-parameter to simplify applying this abstract
+  -- authenticator model to implementations that may wish to make a test of
+  -- user presence optional although WebAuthn does not.
+  -- NOTE: We currently always have user present
+  Bool ->
+  -- | requireUserVerification: The effective user verification requirement for
+  -- credential creation, a Boolean value determined by the client.
+  -- NOTE: We currently always verify the user
+  Bool ->
+  -- | credTypesAndPubKeyAlgs: A sequence of pairs of PublicKeyCredentialType
+  -- and public key algorithms (COSEAlgorithmIdentifier) requested by the
+  -- Relying Party. This sequence is ordered from most preferred to least
+  -- preferred. The authenticator makes a best-effort to create the most
+  -- preferred credential that it can.
+  [M.PublicKeyCredentialParameters] ->
+  -- | excludeCredentialDescriptorList: An OPTIONAL list of
+  -- PublicKeyCredentialDescriptor objects provided by the Relying Party with
+  -- the intention that, if any of these are known to the authenticator, it
+  -- SHOULD NOT create a new credential. excludeCredentialDescriptorList
+  -- contains a list of known credentials.
+  [M.PublicKeyCredentialDescriptor] ->
+  -- | enterpriseAttestationPossible: A Boolean value that indicates that
+  -- individually-identifying attestation MAY be returned by the authenticator.
+  Bool ->
+  -- | extensions: A CBOR map from extension identifiers to their authenticator
+  -- extension inputs, created by the client based on the extensions requested
+  -- by the Relying Party, if any.
+  Maybe M.AuthenticationExtensionsClientInputs ->
+  m (M.AttestationObject, Authenticator)
+authenticatorMakeCredential
+  authenticator@AuthenticatorNone {..}
+  _hash
+  rpEntity
+  userEntity
+  _requireResidentKey
+  _requireUserPresence
+  _requireUserVerification
+  credTypesAndPubKeyAlgs
+  excludeCredentialDescriptorList
+  _enterpriseAttestationPossible
+  _extensions =
+    do
+      -- 1. Check if all the supplied parameters are syntactically well-formed
+      -- and of the correct length. If not, return an error code equivalent to
+      -- "UnknownError" and terminate the operation.
+      -- NOTE: This step is performed during decoding
+      -- NOTE: We assume the client set a rpId if it was initially Nothing.
+      let rpId = fromJust $ M.pkcreId rpEntity
+
+      -- 2. Check if at least one of the specified combinations of
+      -- PublicKeyCredentialType and cryptographic parameters in
+      -- credTypesAndPubKeyAlgs is supported. If not, return an error code
+      -- equivalent to "NotSupportedError" and terminate the operation.
+      param <- case find ((`Set.member` aSupportedAlgorithms) . M.pkcpAlg) credTypesAndPubKeyAlgs of
+        Just param -> pure param
+        Nothing -> fail "NotSupportedError"
+
+      -- 3. For each descriptor of excludeCredentialDescriptorList: If looking up
+      -- descriptor.id in this authenticator returns non-null, and the returned
+      -- item's RP ID and type match rpEntity.id and
+      -- excludeCredentialDescriptorList.type respectively, then collect an
+      -- authorization gesture confirming user consent for creating a new
+      -- credential. The authorization gesture MUST include a test of user
+      -- presence. If the user
+      --   confirms consent to create a new credential:
+      --       return an error code equivalent to "InvalidStateError" and terminate the operation.
+      --   does not consent to create a new credential:
+      --       return an error code equivalent to "NotAllowedError" and terminate the operation.
+      -- NOTE: We do not perform user tests, instead assuming that the user always consents.
+      forM_ excludeCredentialDescriptorList $ \descriptor -> case authenticatorLookupCredential authenticator (M.pkcdId descriptor) of
+        Just item -> do
+          when (rpId == pkcsRpId item) (fail "InvalidStateError")
+        Nothing -> pure ()
+
+      -- 4. If requireResidentKey is true and the authenticator cannot store a
+      -- client-side discoverable public key credential source, return an error
+      -- code equivalent to "ConstraintError" and terminate the operation.
+      -- NOTE: We do not have to do this because the test authenticator supports
+      -- both methods of discoverability
+
+      -- 5. If requireUserVerification is true and the authenticator cannot
+      -- perform user verification, return an error code equivalent to
+      -- "ConstraintError" and terminate the operation.
+      -- NOTE: We do not do this because we fake user verification
+
+      -- 6. Collect an authorization gesture confirming user consent for creating
+      -- a new credential. The prompt for the authorization gesture is shown by
+      -- the authenticator if it has its own output capability, or by the user
+      -- agent otherwise. The prompt SHOULD display rpEntity.id, rpEntity.name,
+      -- userEntity.name and userEntity.displayName, if possible.
+      --   If requireUserVerification is true, the authorization gesture MUST
+      --   include user verification.
+      --   If requireUserPresence is true, the authorization gesture MUST include a
+      --   test of user presence.
+      --   If the user does not consent or if user verification fails, return an
+      --   error code equivalent to "NotAllowedError" and terminate the operation.
+      -- NOTE: We curently always succeed this step
+
+      -- 7. Once the authorization gesture has been completed and user consent
+      -- has been obtained, generate a new credential object:
+      -- 7.1. Let (publicKey, privateKey) be a new pair of cryptographic keys
+      -- using the combination of PublicKeyCredentialType and cryptographic
+      -- parameters represented by the first item in credTypesAndPubKeyAlgs that
+      -- is supported by this authenticator.
+      (publicKey, privateKey) <- newKeyPair $ M.pkcpAlg param
+
+      -- 7.2. Let userHandle be userEntity.id.
+      let userHandle = M.pkcueId userEntity
+
+      -- 7.4 If requireResidentKey is true or the authenticator chooses to
+      -- create a client-side discoverable public key credential source:
+
+      -- 7.4.1 Let credentialId be a new credential id.
+      -- NOTE: We need to have a CredentialId before we can construct the
+      -- credentialSource.
+      -- NOTE: We always choose to construct a clientside discoverable
+      -- credential, as this is allowed (See 7.4).
+      -- TODO: Use deterministic random number generator, and ensure that we
+      -- use a single random number generator across the entire library.
+      credentialId <- M.CredentialId <$> Random.getRandomBytes 16
+
+      -- 7.4.2. Set credentialSource.id to credentialId.
+      -- 7.3.  Let credentialSource be a new public key credential source with the fields:
+      let credentialSource =
+            PublicKeyCredentialSource
+              { pkcsId = credentialId,
+                pkcsPrivateKey = privateKey,
+                pkcsRpId = rpId,
+                pkcsUserHandle = Just userHandle
+              }
+
+      -- 7.4.3 Let credentials be this authenticator’s credentials map.
+      -- NOTE: we have aCredentials from the patternmatch
+      -- 7.4.4 Set credentials[(rpEntity.id, userHandle)] to credentialSource.
+
+      let credentials =
+            Map.insert (rpId, userHandle) credentialSource aCredentials
+
+      -- 8. If any error occurred while creating the new credential object,
+      -- return an error code equivalent to "UnknownError" and terminate the
+      -- operation.
+      -- NOTE: See above
+
+      -- 9. Let processedExtensions be the result of authenticator extension
+      -- processing for each supported extension identifier → authenticator
+      -- extension input in extensions.
+      -- NOTE: Extensions are unsupported
+
+      -- 10. If the authenticator supports a per credential signature counter,
+      -- allocate the counter, associate it with the new credential, and
+      -- initialize the counter value as zero.
+      -- NOTE: We return the updated signature counter and the supposed signatureCount.
+      -- The signatureCount will be 0 if Unsupported
+      let (signatureCounter, aSignatureCounter') = initialiseCounter credentialId aSignatureCounter
+
+      -- 11. Let attestedCredentialData be the attested credential data byte
+      -- array including the credentialId and publicKey.
+      let attestedCredentialData =
+            M.AttestedCredentialData
+              { M.acdAaguid = aAAGUID,
+                M.acdCredentialId = credentialId,
+                M.acdCredentialPublicKey = publicKey, -- This is selfsigned
+                M.acdCredentialPublicKeyBytes = M.PublicKeyBytes . CBOR.toStrictByteString $ PublicKey.encodePublicKey publicKey
+              }
+          attestedCredentialDataBS =
+            encodeAttestedCredentialData attestedCredentialData
+
+      -- 12. Let authenticatorData be the byte array specified in § 6.1
+      -- Authenticator Data, including attestedCredentialData as the
+      -- attestedCredentialData and processedExtensions, if any, as the
+      -- extensions.
+      let rpIdHash = hash . encodeUtf8 . M.unRpId $ rpId
+      let authenticatorData =
+            M.AuthenticatorData
+              { M.adRpIdHash = M.RpIdHash rpIdHash,
+                M.adFlags =
+                  M.AuthenticatorDataFlags
+                    { adfUserPresent = True,
+                      adfUserVerified = True
+                    },
+                M.adSignCount = signatureCounter,
+                M.adAttestedCredentialData = attestedCredentialData,
+                M.adExtensions = Nothing,
+                M.adRawData =
+                  -- TODO: Use Put?
+                  BA.convert rpIdHash
+                    <> BS.singleton 0b01000101
+                    <> (toStrict . runPut $ Put.putWord32be $ M.unSignatureCounter signatureCounter)
+                    <> attestedCredentialDataBS
+              }
+      -- On successful completion of this operation, the authenticator returns
+      -- the attestation object to the client.
+      let attestationObject =
+            M.AttestationObject
+              { aoAuthData = authenticatorData,
+                aoFmt = None.Format,
+                aoAttStmt = ()
+              }
+      pure (attestationObject, authenticator {aCredentials = credentials, aSignatureCounter = aSignatureCounter'})
+    where
+      -- https://www.w3.org/TR/webauthn-2/#sctn-attested-credential-data
+      encodeAttestedCredentialData :: M.AttestedCredentialData 'M.Create -> BS.ByteString
+      encodeAttestedCredentialData M.AttestedCredentialData {..} =
+        M.unAAGUID acdAaguid
+          <> (toStrict . runPut . Put.putWord16be . fromIntegral . BS.length $ M.unCredentialId acdCredentialId)
+          <> M.unCredentialId acdCredentialId
+          <> M.unPublicKeyBytes acdCredentialPublicKeyBytes
+
+      initialiseCounter :: M.CredentialId -> AuthenticatorSignatureCounter -> (M.SignatureCounter, AuthenticatorSignatureCounter)
+      initialiseCounter _ Unsupported = (M.SignatureCounter 0, Unsupported)
+      initialiseCounter _ (Global c) = (c, Global (c + 1))
+      initialiseCounter key (PerCredential m) =
+        let m' = Map.insert key 0 m
+         in (M.SignatureCounter 0, PerCredential m')
+
+-- | [(spec)](https://www.w3.org/TR/webauthn-2/#sctn-op-get-assertion)
+authenticatorGetAssertion ::
+  (MonadRandom m, MonadFail m) =>
+  -- | authenticator: The stored authenticator data
+  Authenticator ->
+  -- | rpId: The caller’s RP ID, as determined by the user agent and the client.
+  M.RpId ->
+  -- | hash: The hash of the serialized client data, provided by the client.
+  M.ClientDataHash ->
+  -- | allowCredentialDescriptorList: An OPTIONAL list of
+  -- PublicKeyCredentialDescriptors describing credentials acceptable to the
+  -- Relying Party (possibly filtered by the client), if any.
+  Maybe [M.PublicKeyCredentialDescriptor] ->
+  -- | requireUserPresence: The constant Boolean value true. It is included here as a
+  -- pseudo-parameter to simplify applying this abstract authenticator model to
+  -- implementations that may wish to make a test of user presence optional
+  -- although WebAuthn does not.
+  Bool ->
+  -- | requireUserVerification: The effective user verification requirement for
+  -- assertion, a Boolean value provided by the client.
+  Bool ->
+  Maybe M.AuthenticationExtensionsClientInputs ->
+  m ((M.CredentialId, M.AuthenticatorData 'M.Get, PrivateKey.Signature, Maybe M.UserHandle), Authenticator)
+authenticatorGetAssertion _ _ _ _ False _ _ = fail "requireUserPresence set to False"
+authenticatorGetAssertion
+  authenticator@AuthenticatorNone {..}
+  rpId
+  clientDataHash
+  allowCredentialDescriptorList
+  True
+  _requireUserVerification
+  _extensions =
+    do
+      -- 1. Check if all the supplied parameters are syntactically well-formed
+      -- and of the correct length. If not, return an error code equivalent to
+      -- "UnknownError" and terminate the operation.
+      -- NOTE: Done during decoding
+
+      -- 2. Let credentialOptions be a new empty set of public key credential
+      -- sources.
+      -- 3. If allowCredentialDescriptorList was supplied, then for each
+      -- descriptor of allowCredentialDescriptorList:
+      -- 3.1. Let credSource be the result of looking up descriptor.id in this authenticator.
+      -- 3.2. If credSource is not null, append it to credentialOptions.
+      -- 4. Otherwise (allowCredentialDescriptorList was not supplied), for each
+      -- key -> credSource of this authenticator’s credentials map, append
+      -- credSource to credentialOptions.
+      -- 5. Remove any items from credentialOptions whose rpId is not equal to rpId.
+      let credentialOptions = filter
+            (\o -> pkcsRpId o == rpId)
+            $ case allowCredentialDescriptorList of
+              Just descriptors -> mapMaybe (authenticatorLookupCredential authenticator . M.pkcdId) descriptors
+              Nothing -> Map.elems aCredentials
+
+      -- 6. If credentialOptions is now empty, return an error code equivalent
+      -- to "NotAllowedError" and terminate the operation.
+      when (null credentialOptions) (fail "NotAllowedError: No CredentialOptions (None of the existing credentials were deemed acceptable)")
+
+      -- 7. Prompt the user to select a public key credential source
+      -- slectedCredential from credentialOptions. Collect an authorization
+      -- gesture confirming user consent for using selectedCredential. The
+      -- prompt for the authorization gesture may be shown by the authenticator
+      -- if it has its own output capability, or by the user agent otherwise.
+
+      -- If requireUserVerification is true, the authorization gesture MUST
+      -- include user verification.
+
+      -- If requireUserPresence is true, the authorization gesture MUST include
+      -- a test of user presence.
+
+      -- If the user does not consent, return an error code equivalent to
+      -- "NotAllowedError" and terminate the operation.
+      -- NOTE: We always assume the user cooperates for now and choses the
+      -- first possible source
+      let selectedCredential = head credentialOptions
+
+      -- 8. Let processedExtensions be the result of authenticator extension
+      -- processing for each supported extension identifier → authenticator
+      -- extension input in extensions.
+      -- TODO: We don't suport extensions
+
+      -- 9. Increment the credential associated signature counter or the global
+      -- signature counter value, depending on which approach is implemented by
+      -- the authenticator, by some positive value. If the authenticator does
+      -- not implement a signature counter, let the signature counter value
+      -- remain constant at zero.
+      let (signatureCounter, aSignatureCounter') = incrementCounter (pkcsId selectedCredential) aSignatureCounter
+
+      -- 10. Let authenticatorData be the byte array specified in § 6.1
+      -- Authenticator Data including processedExtensions, if any, as the
+      -- extensions and excluding attestedCredentialData.
+      -- NOTE: We don't just create the bytearray.
+      let rpIdHash = hash . encodeUtf8 $ M.unRpId rpId
+      let authenticatorData =
+            M.AuthenticatorData
+              { M.adRpIdHash = M.RpIdHash rpIdHash,
+                M.adFlags =
+                  M.AuthenticatorDataFlags
+                    { adfUserPresent = True,
+                      adfUserVerified = True
+                    },
+                M.adSignCount = signatureCounter,
+                M.adAttestedCredentialData = M.NoAttestedCredentialData,
+                M.adExtensions = Nothing,
+                M.adRawData =
+                  -- TODO: Use Put?
+                  BA.convert rpIdHash
+                    <> BS.singleton 0b00000101
+                    <> (toStrict . runPut $ Put.putWord32be . M.unSignatureCounter $ signatureCounter)
+              }
+
+      -- 11. Let signature be the assertion signature of the concatenation
+      -- authenticatorData || hash using the privateKey of selectedCredential
+      -- as shown in Figure , below. A simple, undelimited concatenation is
+      -- safe to use here because the authenticator data describes its own
+      -- length. The hash of the serialized client data (which potentially has
+      -- a variable length) is always the last element.
+      signature <-
+        PrivateKey.sign
+          (pkcsPrivateKey selectedCredential)
+          (M.adRawData authenticatorData <> BA.convert (M.unClientDataHash clientDataHash))
+
+      -- 12. If any error occurred while generating the assertion signature,
+      -- return an error code equivalent to "UnknownError" and terminate the
+      -- operation.
+      -- NOTE: We don't produce any error
+
+      -- 13. Return
+      pure ((pkcsId selectedCredential, authenticatorData, signature, pkcsUserHandle selectedCredential), authenticator {aSignatureCounter = aSignatureCounter'})
+    where
+      -- Increments the signature counter and results in the updated version
+      incrementCounter :: M.CredentialId -> AuthenticatorSignatureCounter -> (M.SignatureCounter, AuthenticatorSignatureCounter)
+      incrementCounter _ Unsupported = (M.SignatureCounter 0, Unsupported)
+      incrementCounter _ (Global c) = (c + 1, Global (c + 1))
+      incrementCounter key (PerCredential m) =
+        -- updateLookupWithKey results in the updated value
+        -- NOTE: Rather sketchy, but should be fine for tests, this map should
+        -- have all credentials
+        let (Just c, m') = Map.updateLookupWithKey (\_ c -> Just $ c + 1) key m
+         in (c, PerCredential m')
+
+-- TODO: Surely there must be a beter function than lookpMin . filter
+authenticatorLookupCredential :: Authenticator -> M.CredentialId -> Maybe PublicKeyCredentialSource
+authenticatorLookupCredential AuthenticatorNone {..} credentialId = snd <$> Map.lookupMin (Map.filter (\PublicKeyCredentialSource {..} -> pkcsId == credentialId) aCredentials)
+
+newKeyPair :: MonadRandom m => PublicKey.COSEAlgorithmIdentifier -> m (PublicKey.PublicKey, PrivateKey.PrivateKey)
+newKeyPair PublicKey.COSEAlgorithmIdentifierES256 = newECDSAKeyPair PublicKey.COSEAlgorithmIdentifierES256
+newKeyPair PublicKey.COSEAlgorithmIdentifierES384 = newECDSAKeyPair PublicKey.COSEAlgorithmIdentifierES384
+newKeyPair PublicKey.COSEAlgorithmIdentifierES512 = newECDSAKeyPair PublicKey.COSEAlgorithmIdentifierES512
+newKeyPair PublicKey.COSEAlgorithmIdentifierEdDSA = do
+  secret <- Ed25519.generateSecretKey
+  let public = Ed25519.toPublic secret
+  pure (PublicKey.Ed25519PublicKey public, PrivateKey.Ed25519PrivateKey secret)
+
+newECDSAKeyPair :: MonadRandom m => PublicKey.COSEAlgorithmIdentifier -> m (PublicKey.PublicKey, PrivateKey.PrivateKey)
+newECDSAKeyPair ident = do
+  let curve = ECC.getCurveByName $ PublicKey.toCurveName ident
+  (public, private) <- ECC.generate curve
+  let privateKey = fromMaybe (error "Not a ECDSAKey") $ PrivateKey.toECDSAKey ident private
+      publicKey = fromMaybe (error "Not a ECDSAKey") $ PublicKey.toECDSAKey ident public
+  pure (publicKey, privateKey)

--- a/tests/Client.hs
+++ b/tests/Client.hs
@@ -1,0 +1,253 @@
+{-# LANGUAGE BinaryLiterals #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
+
+-- | This modules provdes a way to emulate certain client behaviour for testing
+-- purposes. It DOES NOT implement the webauthn specification for two reasons:
+-- 1. There is no need for it in our tests.
+-- 2. It is much more convenient to implement both the client and authenticator
+-- in a single function, removing their communication.
+module Client (clientAssertion, spec) where
+
+import Authenticator
+  ( Authenticator (AuthenticatorNone, aAAGUID, aCredentials, aSignatureCounter, aSupportedAlgorithms),
+    AuthenticatorSignatureCounter (Global),
+    authenticatorGetAssertion,
+    authenticatorMakeCredential,
+  )
+import qualified Client.PrivateKey as PrivateKey
+import qualified Crypto.Fido2.Model as M
+import qualified Crypto.Fido2.Model.JavaScript as JS
+import Crypto.Fido2.Model.JavaScript.Decoding
+  ( decodeCreateCollectedClientData,
+    decodeCreatedPublicKeyCredential,
+    decodeGetCollectedClientData,
+    decodePublicKeyCredentialCreationOptions,
+    decodePublicKeyCredentialRequestOptions,
+    decodeRequestedPublicKeyCredential,
+  )
+import Crypto.Fido2.Model.JavaScript.Encoding
+  ( encodeCreatedPublicKeyCredential,
+    encodePublicKeyCredentialCreationOptions,
+    encodePublicKeyCredentialRequestOptions,
+    encodeRequestedPublicKeyCredential,
+  )
+import qualified Crypto.Fido2.Model.JavaScript.Types as JS
+import Crypto.Fido2.Operations.Attestation (allSupportedFormats)
+import qualified Crypto.Fido2.Operations.Attestation as Fido2
+import qualified Crypto.Fido2.PublicKey as PublicKey
+import Crypto.Hash (hash)
+import Crypto.Random (MonadRandom)
+import Data.Aeson (encode)
+import qualified Data.ByteString.Base64.URL as Base64
+import Data.ByteString.Lazy (toStrict)
+import Data.Either (fromRight, isRight)
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import qualified Data.Set as Set
+import Data.Text.Encoding (decodeUtf8, encodeUtf8)
+import Data.Validation (toEither)
+import Debug.Trace (traceShowId)
+import System.Random.Stateful (globalStdGen, uniformM)
+import Test.Hspec (SpecWith, describe, it, shouldSatisfy)
+
+--- The RpId is derivable from the Origin, but we don't implement that.
+-- See: https://html.spec.whatwg.org/multipage/origin.html#concept-origin-effective-domain
+data AnnotatedOrigin = AnnotatedOrigin
+  { aoRpId :: M.RpId,
+    aoOrigin :: M.Origin
+  }
+
+-- | Emulates the client-side operation for attestation given an authenticator.
+-- MonadRandom is required during the geneation of the new credentials.
+clientAttestation :: (MonadRandom m, MonadFail m) => JS.PublicKeyCredentialCreationOptions -> AnnotatedOrigin -> Authenticator -> m (JS.CreatedPublicKeyCredential, Authenticator)
+clientAttestation options AnnotatedOrigin {..} authenticator = do
+  let M.PublicKeyCredentialCreationOptions {..} =
+        fromRight (error "Test: could not decode creation options") $ decodePublicKeyCredentialCreationOptions options
+      -- We would ideally construct the M.CollectedClientData first, but this
+      -- is impossible since we need the hash. As a workaround we construct
+      -- the encoded version first by manually encoding the intermediate JSON
+      -- representation, allowing us to construct the hash and the
+      -- CollectedClientData from that.
+      clientDataAB =
+        JS.URLEncodedBase64 . toStrict $
+          encode
+            JS.ClientDataJSON
+              { JS.typ = "webauthn.create",
+                JS.challenge = decodeUtf8 . Base64.encode $ M.unChallenge pkcocChallenge,
+                JS.origin = M.unOrigin aoOrigin,
+                JS.crossOrigin = Nothing
+              }
+      clientDataHash = M.ClientDataHash . hash $ JS.unUrlEncodedBase64 clientDataAB
+      clientData = fromRight (error "Test: could not decode encoded clientData") $ traceShowId $ decodeCreateCollectedClientData clientDataAB
+  (attestationObject, authenticator') <-
+    authenticatorMakeCredential
+      authenticator
+      clientDataHash
+      -- Ensure the RpId is set by defaulting to the Client configured default if Nothing
+      (pkcocRp {M.pkcreId = Just . fromMaybe aoRpId $ M.pkcreId pkcocRp})
+      pkcocUser
+      True
+      True
+      True
+      pkcocPubKeyCredParams
+      pkcocExcludeCredentials
+      False
+      pkcocExtensions
+  let response =
+        encodeCreatedPublicKeyCredential
+          M.PublicKeyCredential
+            { M.pkcIdentifier = M.acdCredentialId . M.adAttestedCredentialData $ M.aoAuthData attestationObject,
+              M.pkcResponse =
+                M.AuthenticatorAttestationResponse
+                  { M.arcClientData = clientData,
+                    M.arcAttestationObject = attestationObject,
+                    M.arcTransports = Set.fromList [M.AuthenticatorTransportUSB, M.AuthenticatorTransportBLE, M.AuthenticatorTransportNFC, M.AuthenticatorTransportInternal]
+                  },
+              M.pkcClientExtensionResults = M.AuthenticationExtensionsClientOutputs {}
+            }
+  pure (response, authenticator')
+
+-- | Performs assertion as per the client specification provided an
+-- authenticator. MonadRandom is required for signing using Ed25519 which
+-- requires a random number to be generated during signing. There exists
+-- methods to not rely on a random number, but these have not been implemented
+-- in the cryptonite library we rely on.
+clientAssertion :: (MonadFail m, MonadRandom m) => JS.PublicKeyCredentialRequestOptions -> AnnotatedOrigin -> Authenticator -> m (JS.RequestedPublicKeyCredential, Authenticator)
+clientAssertion options AnnotatedOrigin {..} authenticator = do
+  let Right M.PublicKeyCredentialRequestOptions {..} = decodePublicKeyCredentialRequestOptions options
+      allowCredentialDescriptorList = case pkcogAllowCredentials of
+        [] -> Nothing
+        xs -> Just xs
+      -- We would ideally construct the M.CollectedClientData first, but this
+      -- is impossible since we need the hash. As a workaround we construct
+      -- the encoded version first by manually encoding the intermediate JSON
+      -- representation, allowing us to construct the hash and the
+      -- CollectedClientData from that.
+      clientDataAB =
+        JS.URLEncodedBase64 . toStrict $
+          encode
+            JS.ClientDataJSON
+              { JS.typ = "webauthn.get",
+                JS.challenge = decodeUtf8 . Base64.encode $ M.unChallenge pkcogChallenge,
+                JS.origin = M.unOrigin aoOrigin,
+                JS.crossOrigin = Nothing
+              }
+      clientDataHash = M.ClientDataHash . hash $ JS.unUrlEncodedBase64 clientDataAB
+      clientData = fromRight (error "Test: could not decode encoded clientData") $ decodeGetCollectedClientData clientDataAB
+  ((credentialId, authenticatorData, signature, userHandle), authenticator') <-
+    authenticatorGetAssertion
+      authenticator
+      -- Ensure the RpId is set by defaulting to the Client configured default if Nothing
+      (fromMaybe aoRpId pkcogRpId)
+      clientDataHash
+      allowCredentialDescriptorList
+      True
+      True
+      pkcogExtensions
+  let response =
+        encodeRequestedPublicKeyCredential
+          M.PublicKeyCredential
+            { M.pkcIdentifier = credentialId,
+              M.pkcResponse =
+                M.AuthenticatorAssertionResponse
+                  { M.argClientData = clientData,
+                    M.argAuthenticatorData = authenticatorData,
+                    M.argSignature = M.AssertionSignature $ PrivateKey.toByteString signature,
+                    M.argUserHandle = userHandle
+                  },
+              M.pkcClientExtensionResults = M.AuthenticationExtensionsClientOutputs {}
+            }
+  pure (response, authenticator')
+
+spec :: SpecWith ()
+spec = describe "None" $
+  it "succeeds" $ do
+    -- Generate new random input
+    challenge <- uniformM globalStdGen
+    userId <- uniformM globalStdGen
+    -- Create dummy user
+    let user =
+          M.PublicKeyCredentialUserEntity
+            { M.pkcueId = userId,
+              M.pkcueDisplayName = M.UserAccountDisplayName "John Doe",
+              M.pkcueName = M.UserAccountName "john-doe"
+            }
+    let options = defaultPkcco user challenge
+    let noneAuthenticator =
+          AuthenticatorNone
+            { aCredentials = Map.empty,
+              aSupportedAlgorithms = Set.singleton PublicKey.COSEAlgorithmIdentifierEdDSA,
+              aAAGUID = M.AAGUID "0000000000000000",
+              aSignatureCounter = Global 0
+            }
+    let client =
+          AnnotatedOrigin
+            { aoRpId = M.RpId "localhost",
+              aoOrigin = M.Origin "https://localhost:8080"
+            }
+    -- Perform client Attestation emulation with a fresh authenticator
+    (jsPkcCreate, authenticator) <- clientAttestation (encodePublicKeyCredentialCreationOptions options) client noneAuthenticator
+    let mPkcCreate = decodeCreatedPublicKeyCredential allSupportedFormats jsPkcCreate
+    mPkcCreate `shouldSatisfy` isRight
+    -- Verify the result
+    let registerResult =
+          toEither $
+            Fido2.verifyAttestationResponse
+              (aoOrigin client)
+              (M.RpIdHash . hash . encodeUtf8 . M.unRpId $ aoRpId client)
+              options
+              (fromRight (error "should not happend") mPkcCreate)
+    registerResult `shouldSatisfy` isRight
+    let options = defaultPkcro challenge
+    -- Perform client assertion emulation with the same authenticator, this
+    -- authenticator should now store the created credential
+    (jsPkcGet, _) <- clientAssertion (encodePublicKeyCredentialRequestOptions options) client authenticator
+    let mPkcGet = decodeRequestedPublicKeyCredential jsPkcGet
+    mPkcGet `shouldSatisfy` isRight
+
+-- | Create a default set of options for attestation. These options can be modified before using them in the tests
+defaultPkcco :: M.PublicKeyCredentialUserEntity -> M.Challenge -> M.PublicKeyCredentialOptions 'M.Create
+defaultPkcco userEntity challenge =
+  M.PublicKeyCredentialCreationOptions
+    { M.pkcocRp = M.PublicKeyCredentialRpEntity {M.pkcreId = Nothing, M.pkcreName = "ACME"},
+      M.pkcocUser = userEntity,
+      M.pkcocChallenge = challenge,
+      -- Empty credentialparameters are not supported.
+      M.pkcocPubKeyCredParams =
+        [ M.PublicKeyCredentialParameters
+            { M.pkcpTyp = M.PublicKeyCredentialTypePublicKey,
+              M.pkcpAlg = PublicKey.COSEAlgorithmIdentifierES256
+            },
+          M.PublicKeyCredentialParameters
+            { M.pkcpTyp = M.PublicKeyCredentialTypePublicKey,
+              M.pkcpAlg = PublicKey.COSEAlgorithmIdentifierEdDSA
+            }
+        ],
+      M.pkcocTimeout = Nothing,
+      M.pkcocExcludeCredentials = [],
+      M.pkcocAuthenticatorSelection =
+        Just
+          M.AuthenticatorSelectionCriteria
+            { M.ascAuthenticatorAttachment = Nothing,
+              M.ascResidentKey = M.ResidentKeyRequirementDiscouraged,
+              M.ascUserVerification = M.UserVerificationRequirementPreferred
+            },
+      M.pkcocAttestation = M.AttestationConveyancePreferenceDirect,
+      M.pkcocExtensions = Nothing
+    }
+
+-- | Create a default set of options for assertion. These options can be modified before using them in the tests
+defaultPkcro :: M.Challenge -> M.PublicKeyCredentialOptions 'M.Get
+defaultPkcro challenge =
+  M.PublicKeyCredentialRequestOptions
+    { M.pkcogChallenge = challenge,
+      M.pkcogTimeout = Nothing,
+      M.pkcogRpId = Just "localhost",
+      -- We currently only support Client
+      M.pkcogAllowCredentials = [],
+      M.pkcogUserVerification = M.UserVerificationRequirementPreferred,
+      M.pkcogExtensions = Nothing
+    }

--- a/tests/Client/PrivateKey.hs
+++ b/tests/Client/PrivateKey.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Client.PrivateKey
+  ( PrivateKey (..),
+    Signature (..),
+    sign,
+    toECDSAKey,
+    toByteString,
+  )
+where
+
+import qualified Crypto.Fido2.PublicKey as PublicKey
+import qualified Crypto.Hash as Hash
+import qualified Crypto.PubKey.ECC.ECDSA as ECDSA
+import qualified Crypto.PubKey.Ed25519 as Ed25519
+import Crypto.Random (MonadRandom)
+import qualified Data.ASN1.BinaryEncoding as ASN1
+import qualified Data.ASN1.Encoding as ASN1
+import qualified Data.ASN1.Prim as ASN1
+import qualified Data.ByteArray as BA
+import Data.ByteString (ByteString)
+
+data PrivateKey
+  = ES256PrivateKey ECDSA.PrivateKey
+  | ES384PrivateKey ECDSA.PrivateKey
+  | ES512PrivateKey ECDSA.PrivateKey
+  | Ed25519PrivateKey Ed25519.SecretKey
+  deriving (Eq, Show)
+
+data Signature
+  = ESSignature ECDSA.Signature
+  | Ed25519Signature Ed25519.Signature
+
+toECDSAKey :: MonadFail f => PublicKey.COSEAlgorithmIdentifier -> ECDSA.PrivateKey -> f PrivateKey
+toECDSAKey PublicKey.COSEAlgorithmIdentifierES256 = pure . ES256PrivateKey
+toECDSAKey PublicKey.COSEAlgorithmIdentifierES384 = pure . ES384PrivateKey
+toECDSAKey PublicKey.COSEAlgorithmIdentifierES512 = pure . ES512PrivateKey
+toECDSAKey _ = const $ fail "Not a ECDSA key identifier"
+
+sign :: MonadRandom m => PrivateKey -> ByteString -> m Signature
+sign (ES256PrivateKey key) msg = ESSignature <$> ECDSA.sign key Hash.SHA256 msg
+sign (ES384PrivateKey key) msg = ESSignature <$> ECDSA.sign key Hash.SHA384 msg
+sign (ES512PrivateKey key) msg = ESSignature <$> ECDSA.sign key Hash.SHA512 msg
+sign (Ed25519PrivateKey privateKey) msg = pure . Ed25519Signature $ Ed25519.sign privateKey (Ed25519.toPublic privateKey) msg
+
+toByteString :: Signature -> ByteString
+toByteString (ESSignature ECDSA.Signature {..}) = ASN1.encodeASN1' ASN1.DER [ASN1.Start ASN1.Sequence, ASN1.IntVal sign_r, ASN1.IntVal sign_s, ASN1.End ASN1.Sequence]
+toByteString (Ed25519Signature sig) = BA.convert sig

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -5,6 +5,7 @@ module Main
   )
 where
 
+import qualified Client
 import qualified Crypto.Fido2.Model as M
 import qualified Crypto.Fido2.Model.JavaScript as JS
 import qualified Crypto.Fido2.Model.JavaScript.Decoding as JS
@@ -67,6 +68,9 @@ main = Hspec.hspec $ do
   describe
     "Metadata"
     MetadataSpec.spec
+  describe
+    "Client Emulation"
+    Client.spec
   describe "RegisterAndLogin" $
     it "tests whether the fixed register and login responses are matching" $
       do


### PR DESCRIPTION
This PR emulates the none authenticator following spec and implements a tiny subset of the Client specification (just enough to pass the tests).

It is used to do a full test of Attestation -> Assertion without relying on the json test files.

Ideally we would implement all attestation formats, but implementing just None already implements a significant part of attestation and assertion fully.