### PR TITLE
Retouch Error types

### DIFF
--- a/fido/Crypto/Fido2/Operations/Attestation/AndroidKey.hs
+++ b/fido/Crypto/Fido2/Operations/Attestation/AndroidKey.hs
@@ -139,21 +139,37 @@ data Statement = Statement
   deriving (Eq, Show)
 
 data DecodingError
-  = DecodingErrorUnexpectedCBORStructure (HashMap Text CBOR.Term)
-  | DecodingErrorUnknownAlgorithmIdentifier Int
-  | DecodingErrorCertificate String
-  | DecodingErrorCertificateExtensionMissing
-  | DecodingErrorCertificateExtension String
-  | DecodingErrorPublicKey X509.PubKey
+  = -- | The provided CBOR encoded data was malformed. Either because a field
+    -- was missing, or because the field contained the wrong type of data
+    DecodingErrorUnexpectedCBORStructure (HashMap Text CBOR.Term)
+  | -- | The algorithm identifier was invalid, or unsupported by the library
+    DecodingErrorUnknownAlgorithmIdentifier Int
+  | -- | The x5c field of the attestation statement could not be decoded for
+    -- the provided reason
+    DecodingErrorCertificate String
+  | -- | The required "attestation" extension was not found in the certificate
+    DecodingErrorCertificateExtensionMissing
+  | -- | The required "attestation" extension of the certificate could not be
+    -- decoded
+    DecodingErrorCertificateExtension String
+  | -- | The public key of the certificate could not be decoded
+    DecodingErrorPublicKey X509.PubKey
   deriving (Show, Exception)
 
 data VerificationError
-  = VerificationErrorCertiticatePublicKeyInvalid
-  | VerificationErrorCredentialKeyMismatch
-  | VerificationErrorChallengeMismatch
-  | VerificationErrorAndroidKeyAllApplicationsFieldFound
-  | VerificationErrorAndroidKeyOriginFieldInvalid
-  | VerificationErrorAndroidKeyPurposeFieldInvalid
+  = -- | The public key in the certificate is different from the on in the
+    -- attested credential data
+    VerificationErrorCredentialKeyMismatch
+  | -- | The challenge field of the certificate extension does not match the
+    -- clientDataHash
+    VerificationErrorClientDataHashMismatch
+  | -- | The "attestation" extension is scoped to all applications instead of just the RpId
+    VerificationErrorAndroidKeyAllApplicationsFieldFound
+  | -- | The origin field(s) were not equal to KM_ORIGIN_GENERATED
+    VerificationErrorAndroidKeyOriginFieldInvalid
+  | -- | The purpose field(s) were not equal to the singleton set containing
+    -- KM_PURPOSE_SIGN
+    VerificationErrorAndroidKeyPurposeFieldInvalid
   deriving (Show, Exception)
 
 -- | [(spec)](https://android.googlesource.com/platform/hardware/libhardware/+/master/include/hardware/keymaster_defs.h)
@@ -224,7 +240,7 @@ instance M.AttestationStatementFormat Format where
     -- 4. Verify that the attestationChallenge field in the attestation certificate extension data is identical to
     -- clientDataHash.
     -- See https://source.android.com/security/keystore/attestation for the ASN1 description
-    unless (attestationChallenge attExt == M.unClientDataHash clientDataHash) . Left $ VerificationErrorChallengeMismatch
+    unless (attestationChallenge attExt == M.unClientDataHash clientDataHash) . Left $ VerificationErrorClientDataHashMismatch
 
     -- 5. Verify the following using the appropriate authorization list from the attestation certificate extension data:
 

--- a/fido/Crypto/Fido2/Operations/Attestation/FidoU2F.hs
+++ b/fido/Crypto/Fido2/Operations/Attestation/FidoU2F.hs
@@ -51,11 +51,14 @@ data DecodingError
   deriving (Show, Exception)
 
 data VerifyingError
-  = NoECKeyInCertificate
-  | CredentialDataMissing
-  | NoECKeyInAttestedCredentialData
-  | UnexpectedCoordinateLength
-  | InvalidSignature
+  = -- | The public key in the certificate was not an EC Key or the curve was not the p256 curve
+    IncorrectKeyInCertificate
+  | -- | The key in the attested credential data was not an EC key or the point was the point at infinity
+    NoECKeyInAttestedCredentialData
+  | -- | After encoding the x or y coordinate of the public key did not have the required 32 byte length
+    UnexpectedCoordinateLength
+  | -- | The provided public key cannot validate the signature over the verification data
+    InvalidSignature
   deriving (Show, Exception)
 
 data Statement = Statement
@@ -106,7 +109,7 @@ instance M.AttestationStatementFormat Format where
     case certPubKey of
       -- TODO: Will we only get named curves?
       (X509.PubKeyEC X509.PubKeyEC_Named {X509.pubkeyEC_name = SEC_p256r1}) -> pure ()
-      _ -> Left NoECKeyInCertificate
+      _ -> Left IncorrectKeyInCertificate
 
     -- 3. Extract the claimed rpIdHash from authenticatorData, and the claimed
     -- credentialId and credentialPublicKey from authenticatorData.attestedCredentialData.


### PR DESCRIPTION
This PR mostly documents the Errors. However, in that process I found one error that was unused, one that had a name that was too specific, and one error that could be represented by another. Additionally, I identified one Error that was not yet used, which I documented.