### PR TITLE
Remove an unused binding

### DIFF
--- a/fido/Crypto/Fido2/Model/JavaScript/Decoding.hs
+++ b/fido/Crypto/Fido2/Model/JavaScript/Decoding.hs
@@ -452,7 +452,7 @@ instance DecodeCreated M.AttestationObject where
               first (CreatedDecodingErrorAttestationStatement . SomeException) $
                 asfDecode aoFmt attStmtMap
             pure $ M.AttestationObject {..}
-      terms -> Left $ CreatedDecodingErrorUnexpectedAttestationObjectValues map
+      _ -> Left $ CreatedDecodingErrorUnexpectedAttestationObjectValues map
 
 instance DecodeCreated (M.AuthenticatorResponse 'M.Create) where
   decodeCreated asfMap JS.AuthenticatorAttestationResponse {..} = do


### PR DESCRIPTION
This should have happened in the Error retouching, but slipped through somehow. The `terms` binding was used before in the error message, but we replaced it by the entire `map` for sake of completeness.