### PR TITLE
Raw model fields, full encoding support, roundtrip encoding tests

### DIFF
--- a/fido/Crypto/Fido2/Model.hs
+++ b/fido/Crypto/Fido2/Model.hs
@@ -84,7 +84,6 @@ import Data.HashMap.Strict (HashMap, (!?))
 import qualified Data.HashMap.Strict as HashMap
 import Data.Kind (Type)
 import Data.List.NonEmpty (NonEmpty)
-import Data.Set (Set)
 import Data.String (IsString)
 import Data.Text (Text)
 import Data.Word (Word32)
@@ -759,7 +758,7 @@ data CollectedClientData (t :: WebauthnType) raw = CollectedClientData
     -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dom-collectedclientdata-crossorigin)
     -- This member contains the inverse of the `sameOriginWithAncestors` argument value
     -- that was passed into the [internal method](https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots).
-    ccdCrossOrigin :: Maybe Bool,
+    ccdCrossOrigin :: Bool,
     -- | Raw data of the client data, for verification purposes
     ccdRawData :: RawField raw
     -- TODO: Implement this
@@ -999,14 +998,15 @@ data AuthenticatorResponse (t :: WebauthnType) raw where
       -- For more details, see [§ 6.5 Attestation](https://www.w3.org/TR/webauthn-2/#sctn-attestation),
       -- [§ 6.5.4 Generating an Attestation Object](https://www.w3.org/TR/webauthn-2/#sctn-generating-an-attestation-object),
       -- and [Figure 6](https://www.w3.org/TR/webauthn-2/#fig-attStructs).
-      arcAttestationObject :: AttestationObject raw,
-      -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dom-authenticatorattestationresponse-gettransports)
+      arcAttestationObject :: AttestationObject raw
+      -- TODO: This property is currently not propagated by webauthn-json
+      -- [(spec)](https://www.w3.org/TR/webauthn-2/#dom-authenticatorattestationresponse-gettransports)
       -- This [internal slot](https://tc39.github.io/ecma262/#sec-object-internal-methods-and-internal-slots)
       -- contains a sequence of zero or more unique `[DOMString](https://heycam.github.io/webidl/#idl-DOMString)`s
       -- in lexicographical order. These values are the transports that the
       -- [authenticator](https://www.w3.org/TR/webauthn-2/#authenticator) is believed to support,
       -- or an empty sequence if the information is unavailable.
-      arcTransports :: Set AuthenticatorTransport
+      -- arcTransports :: Set AuthenticatorTransport
     } ->
     AuthenticatorResponse 'Create raw
   -- | [(spec)](https://www.w3.org/TR/webauthn-2/#authenticatorassertionresponse)

--- a/fido/Crypto/Fido2/Model/Binary/Decoding.hs
+++ b/fido/Crypto/Fido2/Model/Binary/Decoding.hs
@@ -1,0 +1,278 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Crypto.Fido2.Model.Binary.Decoding
+  ( -- * Error types
+    DecodingError (..),
+    CreatedDecodingError (..),
+
+    -- * Decoding from bytes
+    decodeAuthenticatorData,
+    decodeAttestationObject,
+    decodeCollectedClientData,
+  )
+where
+
+import qualified Codec.CBOR.Decoding as CBOR
+import qualified Codec.CBOR.Read as CBOR
+import qualified Codec.CBOR.Term as CBOR
+import qualified Codec.Serialise as CBOR
+import Control.Exception (Exception, SomeException (SomeException))
+import Control.Monad (forM, unless)
+import Crypto.Fido2.EncodingUtils (CustomJSON (CustomJSON), JSONEncoding)
+import qualified Crypto.Fido2.Model as M
+import qualified Crypto.Fido2.Model.JavaScript as JS
+import Crypto.Fido2.Model.WebauthnType (SWebauthnType (SCreate, SGet), SingI (sing))
+import Crypto.Fido2.PublicKey (decodePublicKey)
+import qualified Crypto.Fido2.WebIDL as IDL
+import qualified Crypto.Hash as Hash
+import qualified Data.Aeson as Aeson
+import Data.Bifunctor (first, second)
+import qualified Data.Binary.Get as Binary
+import qualified Data.Bits as Bits
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base64.URL as Base64Url
+import qualified Data.ByteString.Lazy as LBS
+import Data.HashMap.Strict (HashMap, (!?))
+import qualified Data.HashMap.Strict as HashMap
+import Data.Maybe (fromJust)
+import Data.Text (Text)
+import qualified Data.Text.Encoding as Text
+import GHC.Generics (Generic)
+
+-- | Decoding errors that can only occur when decoding a
+-- 'M.AttestationObject' result with 'decodeAttestationObject'
+data CreatedDecodingError
+  = -- | Any of the below specified 'DecodingError's occured
+    CreatedDecodingErrorCommon DecodingError
+  | -- | The Attestation format could not be decoded because the provided
+    -- format is not part of the webauthn specification or not supported by this
+    -- library
+    CreatedDecodingErrorUnknownAttestationStatementFormat Text
+  | -- | A CBOR String was expected but a different type was encountered
+    CreatedDecodingErrorUnexpectedAttestationStatementKey CBOR.Term
+  | -- | An error was encountered during the decoding of the attestation
+    -- statement format
+    CreatedDecodingErrorAttestationStatement SomeException
+  | -- | The CBOR-encoded attestation object did not contain the required
+    -- "authData", "fmt" and "attStmt" fields, or their respective values were
+    -- not the correct types
+    CreatedDecodingErrorUnexpectedAttestationObjectValues (HashMap Text CBOR.Term)
+  deriving (Show, Exception)
+
+-- | Decoding errors that can occur when doing binary decoding of webauthn client
+-- responses
+data DecodingError
+  = -- | The Client data could not be decoded for the provided reason
+    DecodingErrorClientDataJSON String
+  | -- | The Challenge could not be decoded from its Base64-based encoding for
+    -- the provided reason
+    DecodingErrorClientDataChallenge String
+  | -- | The Client Data's Webauthn type did not match the expected one
+    -- (first: expected, second: received)
+    DecodingErrorUnexpectedWebauthnType IDL.DOMString IDL.DOMString
+  | -- | The client data had the create type but the authenticator data's
+    -- attested credential data flag was not set.
+    DecodingErrorExpectedAttestedCredentialData
+  | -- | The client data had the get type but the authenticator data's
+    -- attested credential data flag was set.
+    DecodingErrorUnexpectedAttestedCredentialData
+  | -- | After decoding the authenticator data, the data in the error remained
+    -- undecoded
+    DecodingErrorNotAllInputUsed LBS.ByteString
+  | -- | The given error occured during decoding of binary data
+    DecodingErrorBinary String
+  | -- | The given error occured during decoding of CBOR-encoded data
+    DecodingErrorCBOR CBOR.DeserialiseFailure
+  | -- | The decoded algorithm identifier does not match the desired algorithm
+    DecodingErrorUnexpectedAlgorithmIdentifier JS.COSEAlgorithmIdentifier
+  deriving (Show, Exception)
+
+-- | Webauthn contains a mixture of binary formats. For one it's CBOR and
+-- for another it's a custom format. For CBOR we wish to use the
+-- [cborg](https://hackage.haskell.org/package/cborg) library
+-- and for the custom binary format the [binary](https://hackage.haskell.org/package/binary)
+-- library. However these two libraries don't interact nicely with each other.
+-- Because of this we are specifying the decoders as a 'PartialBinaryDecoder DecodingError',
+-- which is just a function that can partially consume a 'LBS.ByteString'.
+-- Using this we can somewhat easily flip between the two libraries while
+-- decoding without too much nastiness.
+type PartialBinaryDecoder e a = LBS.ByteString -> Either e (LBS.ByteString, a)
+
+-- | A 'PartialBinaryDecoder DecodingError' for a binary encoding specified using 'Binary.Get'
+runBinary :: Binary.Get a -> PartialBinaryDecoder DecodingError a
+runBinary get bytes = case Binary.runGetOrFail get bytes of
+  Left (_rest, _offset, err) -> Left $ DecodingErrorBinary err
+  Right (rest, _offset, result) -> Right (rest, result)
+
+-- | A 'PartialBinaryDecoder DecodingError' for a CBOR encoding specified using the given Decoder
+runCBOR :: (forall s. CBOR.Decoder s a) -> PartialBinaryDecoder DecodingError (LBS.ByteString, a)
+runCBOR decoder bytes = case CBOR.deserialiseFromBytesWithSize decoder bytes of
+  Left err -> Left $ DecodingErrorCBOR err
+  Right (rest, consumed, a) -> return (rest, (LBS.take (fromIntegral consumed) bytes, a))
+
+-- | Decodes a 'M.AuthenticatorData' from a 'BS.ByteString'.
+-- This is needed to parse a webauthn clients
+-- [authenticatorData](https://www.w3.org/TR/webauthn-2/#dom-authenticatorassertionresponse-authenticatordata)
+-- field in the [AuthenticatorAssertionResponse](https://www.w3.org/TR/webauthn-2/#iface-authenticatorassertionresponse)
+-- structure
+decodeAuthenticatorData ::
+  forall t.
+  SingI t =>
+  BS.ByteString ->
+  Either DecodingError (M.AuthenticatorData t 'True)
+decodeAuthenticatorData strictBytes = do
+  -- https://www.w3.org/TR/webauthn-2/#authenticator-data
+  let bytes = LBS.fromStrict strictBytes
+      adRawData = M.WithRaw strictBytes
+  -- https://www.w3.org/TR/webauthn-2/#rpidhash
+  (bytes, adRpIdHash) <-
+    second (M.RpIdHash . fromJust . Hash.digestFromByteString)
+      <$> runBinary (Binary.getByteString 32) bytes
+
+  -- https://www.w3.org/TR/webauthn-2/#flags
+  (bytes, bitFlags) <-
+    runBinary Binary.getWord8 bytes
+  let adFlags =
+        M.AuthenticatorDataFlags
+          { M.adfUserPresent = Bits.testBit bitFlags 0,
+            M.adfUserVerified = Bits.testBit bitFlags 2
+          }
+
+  -- https://www.w3.org/TR/webauthn-2/#signcount
+  (bytes, adSignCount) <-
+    second M.SignatureCounter
+      <$> runBinary Binary.getWord32be bytes
+
+  -- https://www.w3.org/TR/webauthn-2/#attestedcredentialdata
+  (bytes, adAttestedCredentialData) <- case (sing @t, Bits.testBit bitFlags 6) of
+    -- For [attestation signatures](https://www.w3.org/TR/webauthn-2/#attestation-signature),
+    -- the authenticator MUST set the AT [flag](https://www.w3.org/TR/webauthn-2/#flags)
+    -- and include the `[attestedCredentialData](https://www.w3.org/TR/webauthn-2/#attestedcredentialdata)`.
+    (SCreate, True) -> decodeAttestedCredentialData bytes
+    (SCreate, False) -> Left DecodingErrorExpectedAttestedCredentialData
+    -- For [assertion signatures](https://www.w3.org/TR/webauthn-2/#assertion-signature),
+    -- the AT [flag](https://www.w3.org/TR/webauthn-2/#flags) MUST NOT be set and the
+    -- `[attestedCredentialData](https://www.w3.org/TR/webauthn-2/#attestedcredentialdata)` MUST NOT be included.
+    (SGet, False) -> pure (bytes, M.NoAttestedCredentialData)
+    (SGet, True) -> Left DecodingErrorUnexpectedAttestedCredentialData
+
+  -- https://www.w3.org/TR/webauthn-2/#authdataextensions
+  (bytes, adExtensions) <-
+    if Bits.testBit bitFlags 7
+      then fmap Just <$> decodeExtensions bytes
+      else pure (bytes, Nothing)
+
+  if LBS.null bytes
+    then pure M.AuthenticatorData {..}
+    else Left $ DecodingErrorNotAllInputUsed bytes
+  where
+    decodeAttestedCredentialData :: PartialBinaryDecoder DecodingError (M.AttestedCredentialData 'M.Create 'True)
+    decodeAttestedCredentialData bytes = do
+      -- https://www.w3.org/TR/webauthn-2/#aaguid
+      (bytes, acdAaguid) <-
+        second M.AAGUID
+          <$> runBinary (Binary.getByteString 16) bytes
+
+      -- https://www.w3.org/TR/webauthn-2/#credentialidlength
+      (bytes, credentialLength) <-
+        runBinary Binary.getWord16be bytes
+
+      -- https://www.w3.org/TR/webauthn-2/#credentialid
+      (bytes, acdCredentialId) <-
+        second M.CredentialId
+          <$> runBinary (Binary.getByteString (fromIntegral credentialLength)) bytes
+
+      -- https://www.w3.org/TR/webauthn-2/#credentialpublickey
+      (bytes, (usedBytes, acdCredentialPublicKey)) <-
+        runCBOR decodePublicKey bytes
+      let acdCredentialPublicKeyBytes = M.WithRaw $ LBS.toStrict usedBytes
+
+      pure (bytes, M.AttestedCredentialData {..})
+
+    decodeExtensions :: PartialBinaryDecoder DecodingError M.AuthenticatorExtensionOutputs
+    decodeExtensions bytes = do
+      -- TODO
+      (bytes, (_, _extensions :: HashMap Text CBOR.Term)) <- runCBOR CBOR.decode bytes
+      pure (bytes, M.AuthenticatorExtensionOutputs {})
+
+-- | Decodes a 'M.AttestationObject' from a 'BS.ByteString'. This is needed
+-- to parse a clients webauthn response for attestation only. This function takes
+-- a 'M.SupportedAttestationStatementFormats' argument to indicate which
+-- attestation statement formats are supported.
+--
+-- | Decodes a 'M.AttestationObject' from a 'BS.ByteString'.
+-- This is needed to parse a webauthn clients
+-- [attestationObject](https://www.w3.org/TR/webauthn-2/#dom-authenticatorattestationresponse-attestationobject)
+-- field in the [AuthenticatorAttestationResponse](https://www.w3.org/TR/webauthn-2/#iface-authenticatorattestationresponse)
+-- structure
+decodeAttestationObject :: M.SupportedAttestationStatementFormats -> BS.ByteString -> Either CreatedDecodingError (M.AttestationObject 'True)
+decodeAttestationObject supportedFormats bytes = do
+  -- https://www.w3.org/TR/webauthn-2/#sctn-generating-an-attestation-object
+  map :: HashMap Text CBOR.Term <- first (CreatedDecodingErrorCommon . DecodingErrorCBOR) $ CBOR.deserialiseOrFail $ LBS.fromStrict bytes
+  case (map !? "authData", map !? "fmt", map !? "attStmt") of
+    (Just (CBOR.TBytes authDataBytes), Just (CBOR.TString fmt), Just (CBOR.TMap attStmtPairs)) -> do
+      aoAuthData <- first CreatedDecodingErrorCommon $ decodeAuthenticatorData authDataBytes
+
+      case M.sasfLookup fmt supportedFormats of
+        Nothing -> Left $ CreatedDecodingErrorUnknownAttestationStatementFormat fmt
+        Just (M.SomeAttestationStatementFormat aoFmt) -> do
+          attStmtMap <-
+            HashMap.fromList <$> forM attStmtPairs \case
+              (CBOR.TString text, term) -> pure (text, term)
+              (nonString, _) -> Left $ CreatedDecodingErrorUnexpectedAttestationStatementKey nonString
+          aoAttStmt <-
+            first (CreatedDecodingErrorAttestationStatement . SomeException) $
+              M.asfDecode aoFmt attStmtMap
+          pure M.AttestationObject {..}
+    _ -> Left $ CreatedDecodingErrorUnexpectedAttestationObjectValues map
+
+--- | [(spec)](https://www.w3.org/TR/webauthn-2/#dictionary-client-data)
+--- Intermediate type used to extract the JSON structure stored in the
+--- CBOR-encoded [clientDataJSON](https://www.w3.org/TR/webauthn-2/#dom-authenticatorresponse-clientdatajson).
+data ClientDataJSON = ClientDataJSON
+  { littype :: IDL.DOMString,
+    challenge :: IDL.DOMString,
+    origin :: IDL.DOMString,
+    crossOrigin :: Maybe Bool
+    -- TODO
+    -- tokenBinding :: Maybe TokenBinding
+  }
+  deriving (Generic)
+  -- Note: Encoding should NOT be derived via aeson. See the Encoding module instead
+  deriving (Aeson.FromJSON) via JSONEncoding ClientDataJSON
+
+-- | Decodes a 'M.CollectedClientData' from a 'BS.ByteString'. This is needed
+-- to parse the [clientDataJSON](https://www.w3.org/TR/webauthn-2/#dom-authenticatorresponse-clientdatajson)
+-- field in the [AuthenticatorResponse](https://www.w3.org/TR/webauthn-2/#iface-authenticatorresponse)
+-- structure, which is used for both attestation and assertion
+decodeCollectedClientData :: forall t. SingI t => BS.ByteString -> Either DecodingError (M.CollectedClientData t 'True)
+decodeCollectedClientData bytes = do
+  -- https://www.w3.org/TR/webauthn-2/#collectedclientdata-json-compatible-serialization-of-client-data
+  ClientDataJSON {..} <- first DecodingErrorClientDataJSON $ Aeson.eitherDecodeStrict bytes
+  -- [(spec)](https://www.w3.org/TR/webauthn-2/#dom-collectedclientdata-challenge)
+  -- This member contains the base64url encoding of the challenge provided by the
+  -- [Relying Party](https://www.w3.org/TR/webauthn-2/#relying-party). See the
+  -- [§ 13.4.3 Cryptographic Challenges](https://www.w3.org/TR/webauthn-2/#sctn-cryptographic-challenges)
+  -- security consideration.
+  challenge <- first DecodingErrorClientDataChallenge $ Base64Url.decode (Text.encodeUtf8 challenge)
+  -- [(spec)](https://www.w3.org/TR/webauthn-2/#dom-collectedclientdata-type)
+  -- This member contains the string "webauthn.create" when creating new credentials,
+  -- and "webauthn.get" when getting an assertion from an existing credential.
+  -- The purpose of this member is to prevent certain types of signature confusion
+  -- attacks (where an attacker substitutes one legitimate signature for another).
+  let expectedType = case sing @t of
+        SCreate -> "webauthn.create"
+        SGet -> "webauthn.get"
+  unless (littype == expectedType) $ Left (DecodingErrorUnexpectedWebauthnType expectedType littype)
+  pure
+    M.CollectedClientData
+      { ccdChallenge = M.Challenge challenge,
+        ccdOrigin = M.Origin origin,
+        ccdCrossOrigin = crossOrigin,
+        ccdRawData = M.WithRaw bytes
+      }

--- a/fido/Crypto/Fido2/Model/Binary/Decoding.hs
+++ b/fido/Crypto/Fido2/Model/Binary/Decoding.hs
@@ -39,7 +39,7 @@ import qualified Data.ByteString.Base64.URL as Base64Url
 import qualified Data.ByteString.Lazy as LBS
 import Data.HashMap.Strict (HashMap, (!?))
 import qualified Data.HashMap.Strict as HashMap
-import Data.Maybe (fromJust)
+import Data.Maybe (fromJust, fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text.Encoding as Text
 import GHC.Generics (Generic)
@@ -238,7 +238,7 @@ data ClientDataJSON = ClientDataJSON
   { littype :: IDL.DOMString,
     challenge :: IDL.DOMString,
     origin :: IDL.DOMString,
-    crossOrigin :: Maybe Bool
+    crossOrigin :: Maybe IDL.Boolean
     -- TODO
     -- tokenBinding :: Maybe TokenBinding
   }
@@ -273,6 +273,6 @@ decodeCollectedClientData bytes = do
     M.CollectedClientData
       { ccdChallenge = M.Challenge challenge,
         ccdOrigin = M.Origin origin,
-        ccdCrossOrigin = crossOrigin,
+        ccdCrossOrigin = fromMaybe False crossOrigin,
         ccdRawData = M.WithRaw bytes
       }

--- a/fido/Crypto/Fido2/Model/Binary/Encoding.hs
+++ b/fido/Crypto/Fido2/Model/Binary/Encoding.hs
@@ -1,0 +1,200 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Crypto.Fido2.Model.Binary.Encoding
+  ( -- * Encoding raw fields
+    encodeRawPublicKeyCredential,
+    encodeRawAuthenticatorData,
+    encodeRawCollectedClientData,
+
+    -- * Encoding structures to bytes
+    encodeAttestationObject,
+    encodeCollectedClientData,
+  )
+where
+
+import qualified Codec.CBOR.Term as CBOR
+import qualified Codec.CBOR.Write as CBOR
+import qualified Codec.Serialise as CBOR
+import qualified Crypto.Fido2.Model as M
+import Crypto.Fido2.Model.WebauthnType (SWebauthnType (SCreate, SGet), SingI, sing)
+import Crypto.Fido2.PublicKey (encodePublicKey)
+import qualified Data.Aeson as Aeson
+import qualified Data.Binary.Put as Binary
+import Data.Bits ((.|.))
+import qualified Data.Bits as Bits
+import Data.ByteArray (convert)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base64.URL as Base64Url
+import Data.ByteString.Builder (Builder, stringUtf8, toLazyByteString)
+import qualified Data.ByteString.Lazy as LBS
+import Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HashMap
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Text.Encoding (decodeUtf8)
+import Data.Word (Word16, Word8)
+
+-- | Encodes all raw fields of a 'M.PublicKeyCredential'. This function is
+-- mainly useful for testing that the encoding/decoding functions are correct
+encodeRawPublicKeyCredential :: forall t raw. SingI t => M.PublicKeyCredential t raw -> M.PublicKeyCredential t 'True
+encodeRawPublicKeyCredential M.PublicKeyCredential {..} =
+  M.PublicKeyCredential
+    { pkcResponse = case sing @t of
+        SCreate -> encodeRawAuthenticatorAttestationResponse pkcResponse
+        SGet -> encodeRawAuthenticatorAssertionResponse pkcResponse,
+      ..
+    }
+  where
+    encodeRawAuthenticatorAssertionResponse :: M.AuthenticatorResponse 'M.Get raw -> M.AuthenticatorResponse 'M.Get 'True
+    encodeRawAuthenticatorAssertionResponse M.AuthenticatorAssertionResponse {..} =
+      M.AuthenticatorAssertionResponse
+        { argClientData = encodeRawCollectedClientData argClientData,
+          argAuthenticatorData = encodeRawAuthenticatorData argAuthenticatorData,
+          ..
+        }
+
+    encodeRawAuthenticatorAttestationResponse :: M.AuthenticatorResponse 'M.Create raw -> M.AuthenticatorResponse 'M.Create 'True
+    encodeRawAuthenticatorAttestationResponse M.AuthenticatorAttestationResponse {..} =
+      M.AuthenticatorAttestationResponse
+        { arcClientData = encodeRawCollectedClientData arcClientData,
+          arcAttestationObject = encodeRawAttestationObject arcAttestationObject,
+          ..
+        }
+
+    encodeRawAttestationObject :: M.AttestationObject raw -> M.AttestationObject 'True
+    encodeRawAttestationObject M.AttestationObject {..} =
+      M.AttestationObject
+        { aoAuthData = encodeRawAuthenticatorData aoAuthData,
+          ..
+        }
+
+-- | Encodes all raw fields of a 'M.AuthenticatorData'. This function is needed
+-- for an authenticator implementation
+encodeRawAuthenticatorData :: forall t raw. SingI t => M.AuthenticatorData t raw -> M.AuthenticatorData t 'True
+encodeRawAuthenticatorData M.AuthenticatorData {..} =
+  M.AuthenticatorData
+    { adRawData = M.WithRaw bytes,
+      adAttestedCredentialData = rawAttestedCredentialData,
+      ..
+    }
+  where
+    rawAttestedCredentialData = encodeRawAttestedCredentialData adAttestedCredentialData
+
+    bytes :: BS.ByteString
+    bytes = LBS.toStrict $ toLazyByteString builder
+
+    -- https://www.w3.org/TR/webauthn-2/#flags
+    flags :: Word8
+    flags =
+      userPresentFlag
+        .|. userVerifiedFlag
+        .|. attestedCredentialDataPresentFlag
+        .|. extensionsPresentFlag
+      where
+        userPresentFlag = if M.adfUserPresent adFlags then Bits.bit 0 else 0
+        userVerifiedFlag = if M.adfUserVerified adFlags then Bits.bit 2 else 0
+        attestedCredentialDataPresentFlag = case sing @t of
+          SCreate -> Bits.bit 6
+          SGet -> 0
+        extensionsPresentFlag = case adExtensions of
+          Just _ -> Bits.bit 7
+          Nothing -> 0
+
+    -- https://www.w3.org/TR/webauthn-2/#sctn-authenticator-data
+    builder :: Builder
+    builder =
+      Binary.execPut (Binary.putByteString $ convert $ M.unRpIdHash adRpIdHash)
+        <> Binary.execPut (Binary.putWord8 flags)
+        <> Binary.execPut (Binary.putWord32be $ M.unSignatureCounter adSignCount)
+        <> ( case sing @t of
+               SCreate -> encodeAttestedCredentialData rawAttestedCredentialData
+               SGet -> mempty
+           )
+        <> maybe mempty encodeExtensions adExtensions
+
+    encodeExtensions :: M.AuthenticatorExtensionOutputs -> Builder
+    encodeExtensions M.AuthenticatorExtensionOutputs {} = CBOR.toBuilder $ CBOR.encode entries
+      where
+        entries :: HashMap Text CBOR.Term
+        entries = HashMap.empty
+
+    -- https://www.w3.org/TR/webauthn-2/#sctn-attested-credential-data
+    encodeAttestedCredentialData :: M.AttestedCredentialData 'M.Create 'True -> Builder
+    encodeAttestedCredentialData M.AttestedCredentialData {..} =
+      Binary.execPut (Binary.putByteString $ M.unAAGUID acdAaguid)
+        <> Binary.execPut (Binary.putWord16be credentialLength)
+        <> Binary.execPut (Binary.putByteString $ M.unCredentialId acdCredentialId)
+        <> Binary.execPut (Binary.putByteString $ M.unRaw acdCredentialPublicKeyBytes)
+      where
+        credentialLength :: Word16
+        credentialLength = fromIntegral $ BS.length $ M.unCredentialId acdCredentialId
+
+    encodeRawAttestedCredentialData :: forall t raw. SingI t => M.AttestedCredentialData t raw -> M.AttestedCredentialData t 'True
+    encodeRawAttestedCredentialData = case sing @t of
+      SCreate -> \M.AttestedCredentialData {..} ->
+        M.AttestedCredentialData
+          { acdCredentialPublicKeyBytes =
+              M.WithRaw $ LBS.toStrict $ CBOR.toLazyByteString $ encodePublicKey acdCredentialPublicKey,
+            ..
+          }
+      SGet -> \M.NoAttestedCredentialData -> M.NoAttestedCredentialData
+
+-- | Encodes all raw fields of a 'M.CollectedClientData'. This function is
+-- needed for a client implementation
+encodeRawCollectedClientData :: forall t raw. SingI t => M.CollectedClientData t raw -> M.CollectedClientData t 'True
+encodeRawCollectedClientData M.CollectedClientData {..} = M.CollectedClientData {..}
+  where
+    ccdRawData = M.WithRaw $ LBS.toStrict $ toLazyByteString builder
+
+    -- https://www.w3.org/TR/webauthn-2/#clientdatajson-serialization
+    builder :: Builder
+    builder =
+      stringUtf8 "{\"type\":"
+        <> jsonBuilder typeValue
+        <> stringUtf8 ",\"challenge\":"
+        <> jsonBuilder challengeValue
+        <> stringUtf8 ",\"origin\":"
+        <> jsonBuilder originValue
+        <> stringUtf8 ",\"crossOrigin\":"
+        <> jsonBuilder crossOriginValue
+        <> stringUtf8 "}"
+
+    typeValue :: Text
+    typeValue = case sing @t of
+      SCreate -> "webauthn.create"
+      SGet -> "webauthn.get"
+
+    challengeValue :: Text
+    challengeValue = decodeUtf8 (Base64Url.encode (M.unChallenge ccdChallenge))
+
+    originValue :: Text
+    originValue = M.unOrigin ccdOrigin
+
+    crossOriginValue :: Bool
+    crossOriginValue = fromMaybe False ccdCrossOrigin
+
+    jsonBuilder :: Aeson.ToJSON a => a -> Builder
+    jsonBuilder = Aeson.fromEncoding . Aeson.toEncoding
+
+-- | Encodes an 'M.AttestationObject' as a 'BS.ByteString'. This is needed by
+-- the client side to generate a valid JSON response
+encodeAttestationObject :: M.AttestationObject 'True -> BS.ByteString
+encodeAttestationObject M.AttestationObject {..} = CBOR.toStrictByteString $ CBOR.encodeTerm term
+  where
+    -- https://www.w3.org/TR/webauthn-2/#sctn-generating-an-attestation-object
+    term :: CBOR.Term
+    term =
+      CBOR.TMap
+        [ (CBOR.TString "authData", CBOR.TBytes $ M.unRaw $ M.adRawData aoAuthData),
+          (CBOR.TString "fmt", CBOR.TString $ M.asfIdentifier aoFmt),
+          (CBOR.TString "attStmt", M.asfEncode aoFmt aoAttStmt)
+        ]
+
+-- | Encodes an 'M.CollectedClientData' as a 'BS.ByteString'. This is needed by
+-- the client side to generate a valid JSON response
+encodeCollectedClientData :: forall t. SingI t => M.CollectedClientData t 'True -> BS.ByteString
+encodeCollectedClientData M.CollectedClientData {..} = M.unRaw ccdRawData

--- a/fido/Crypto/Fido2/Model/Binary/Encoding.hs
+++ b/fido/Crypto/Fido2/Model/Binary/Encoding.hs
@@ -33,7 +33,6 @@ import Data.ByteString.Builder (Builder, stringUtf8, toLazyByteString)
 import qualified Data.ByteString.Lazy as LBS
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
-import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8)
 import Data.Word (Word16, Word8)
@@ -175,7 +174,7 @@ encodeRawCollectedClientData M.CollectedClientData {..} = M.CollectedClientData 
     originValue = M.unOrigin ccdOrigin
 
     crossOriginValue :: Bool
-    crossOriginValue = fromMaybe False ccdCrossOrigin
+    crossOriginValue = ccdCrossOrigin
 
     jsonBuilder :: Aeson.ToJSON a => a -> Builder
     jsonBuilder = Aeson.fromEncoding . Aeson.toEncoding

--- a/fido/Crypto/Fido2/Model/JavaScript/Decoding.hs
+++ b/fido/Crypto/Fido2/Model/JavaScript/Decoding.hs
@@ -36,7 +36,6 @@ import qualified Crypto.Fido2.WebIDL as IDL
 import Data.Bifunctor (first)
 import Data.Coerce (Coercible, coerce)
 import Data.Maybe (catMaybes, mapMaybe)
-import qualified Data.Set as Set
 
 -- | @'Decode' a@ indicates that the Haskell-specific type @a@ can be
 -- decoded from the more generic JavaScript type @'JS' a@ with the 'decode' function.
@@ -242,8 +241,6 @@ instance DecodeCreated (M.AuthenticatorResponse 'M.Create 'True) where
   decodeCreated asfMap JS.AuthenticatorAttestationResponse {..} = do
     arcClientData <- first MD.CreatedDecodingErrorCommon $ decode clientDataJSON
     arcAttestationObject <- decodeCreated asfMap attestationObject
-    -- TODO: The webauthn-json library doesn't currently pass the transports
-    let arcTransports = Set.empty
     pure $ M.AuthenticatorAttestationResponse {..}
 
 instance DecodeCreated (M.PublicKeyCredential 'M.Create 'True) where

--- a/fido/Crypto/Fido2/Model/JavaScript/Decoding.hs
+++ b/fido/Crypto/Fido2/Model/JavaScript/Decoding.hs
@@ -16,210 +16,33 @@
 -- and [Verifying an Authentication Assertion](https://www.w3.org/TR/webauthn-2/#sctn-verifying-assertion) respectively.
 module Crypto.Fido2.Model.JavaScript.Decoding
   ( -- * Decoding PublicKeyCredential results
-    DecodingError (..),
-    CreatedDecodingError (..),
     decodeCreatedPublicKeyCredential,
     decodeRequestedPublicKeyCredential,
     decodePublicKeyCredentialCreationOptions,
     decodePublicKeyCredentialRequestOptions,
-    decodeCreateCollectedClientData,
-    decodeGetCollectedClientData,
   )
 where
 
-import qualified Codec.CBOR.Decoding as CBOR
-import qualified Codec.CBOR.Read as CBOR
-import qualified Codec.CBOR.Term as CBOR
-import qualified Codec.Serialise as CBOR
-import Control.Exception (Exception, SomeException (SomeException))
-import Control.Monad (forM, unless)
 import Crypto.Fido2.Model
-  ( AttestationStatementFormat (asfDecode),
-    SomeAttestationStatementFormat (SomeAttestationStatementFormat),
-    SupportedAttestationStatementFormats,
-    sasfLookup,
+  ( SupportedAttestationStatementFormats,
   )
 import qualified Crypto.Fido2.Model as M
+import qualified Crypto.Fido2.Model.Binary.Decoding as MD
 import qualified Crypto.Fido2.Model.JavaScript as JS
 import Crypto.Fido2.Model.JavaScript.Types (Convert (JS))
-import qualified Crypto.Fido2.Model.JavaScript.Types as JS
-import Crypto.Fido2.Model.WebauthnType (SWebauthnType (SCreate, SGet), SingI (sing))
-import Crypto.Fido2.PublicKey (decodePublicKey)
+import Crypto.Fido2.Model.WebauthnType (SingI)
 import qualified Crypto.Fido2.PublicKey as PublicKey
 import qualified Crypto.Fido2.WebIDL as IDL
-import qualified Crypto.Hash as Hash
-import qualified Data.Aeson as Aeson
-import Data.Bifunctor (first, second)
-import qualified Data.Binary.Get as Binary
-import qualified Data.Bits as Bits
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Base64.URL as Base64
-import qualified Data.ByteString.Lazy as LBS
+import Data.Bifunctor (first)
 import Data.Coerce (Coercible, coerce)
-import Data.HashMap.Strict (HashMap, (!?))
-import qualified Data.HashMap.Strict as HashMap
-import Data.Maybe (catMaybes, fromJust, mapMaybe)
+import Data.Maybe (catMaybes, mapMaybe)
 import qualified Data.Set as Set
-import Data.Text (Text)
-import qualified Data.Text.Encoding as Text
-
--- | Decoding errors that can only occur when decoding a
--- 'JS.CreatedPublicKeyCredential' result with 'decodeCreatedPublicKeyCredential'
-data CreatedDecodingError
-  = -- | Any of the below specified 'DecodingError's occured
-    CreatedDecodingErrorCommon DecodingError
-  | -- | The Attestation format could not be decoded because the provided
-    -- format is not part of the webauthn specification or not supported by this
-    -- library
-    CreatedDecodingErrorUnknownAttestationStatementFormat Text
-  | -- | A CBOR String was expected but a different type was encountered
-    CreatedDecodingErrorUnexpectedAttestationStatementKey CBOR.Term
-  | -- | An error was encountered during the decoding of the attestation
-    -- statement format
-    CreatedDecodingErrorAttestationStatement SomeException
-  | -- | The CBOR-encoded attestation object did not contain the required
-    -- "authData", "fmt" and "attStmt" fields, or their respective values were
-    -- not the correct types
-    CreatedDecodingErrorUnexpectedAttestationObjectValues (HashMap Text CBOR.Term)
-  deriving (Show, Exception)
-
--- | Decoding errors that can occur when decoding either a
--- 'JS.CreatedPublicKeyCredential' result with 'decodeCreatedPublicKeyCredential'
--- or a 'JS.RequestedPublicKeyCredential' result with 'decodeRequestedPublicKeyCredential'
-data DecodingError
-  = -- | The Client data could not be decoded for the provided reason
-    DecodingErrorClientDataJSON String
-  | -- | The Challenge could not be decoded from its Base64-based encoding for
-    -- the provided reason
-    DecodingErrorClientDataChallenge String
-  | -- | The Client Data's Webauthn type did not match the expected one
-    -- (first: expected, second: received)
-    DecodingErrorUnexpectedWebauthnType IDL.DOMString IDL.DOMString
-  | -- | The client data had the create type but the authenticator data's
-    -- attested credential data flag was not set.
-    DecodingErrorExpectedAttestedCredentialData
-  | -- | The client data had the get type but the authenticator data's
-    -- attested credential data flag was set.
-    DecodingErrorUnexpectedAttestedCredentialData
-  | -- | After decoding the authenticator data, the data in the error remained
-    -- undecoded
-    DecodingErrorNotAllInputUsed LBS.ByteString
-  | -- | The given error occured during decoding of binary data
-    DecodingErrorBinary String
-  | -- | The given error occured during decoding of CBOR-encoded data
-    DecodingErrorCBOR CBOR.DeserialiseFailure
-  | -- | The decoded algorithm identifier does not match the desired algorithm
-    DecodingErrorUnexpectedAlgorithmIdentifier JS.COSEAlgorithmIdentifier
-  deriving (Show, Exception)
-
--- | Webauthn contains a mixture of binary formats. For one it's CBOR and
--- for another it's a custom format. For CBOR we wish to use the
--- [cborg](https://hackage.haskell.org/package/cborg) library
--- and for the custom binary format the [binary](https://hackage.haskell.org/package/binary)
--- library. However these two libraries don't interact nicely with each other.
--- Because of this we are specifying the decoders as a 'PartialBinaryDecoder',
--- which is just a function that can partially consume a 'LBS.ByteString'.
--- Using this we can somewhat easily flip between the two libraries while
--- decoding without too much nastiness.
-type PartialBinaryDecoder a = LBS.ByteString -> Either DecodingError (LBS.ByteString, a)
-
--- | A 'PartialBinaryDecoder' for a binary encoding specified using 'Binary.Get'
-runBinary :: Binary.Get a -> PartialBinaryDecoder a
-runBinary get bytes = case Binary.runGetOrFail get bytes of
-  Left (_rest, _offset, err) -> Left $ DecodingErrorBinary err
-  Right (rest, _offset, result) -> Right (rest, result)
-
--- | A 'PartialBinaryDecoder' for a CBOR encoding specified using the given Decoder
-runCBOR :: (forall s. CBOR.Decoder s a) -> PartialBinaryDecoder (LBS.ByteString, a)
-runCBOR decoder bytes = case CBOR.deserialiseFromBytesWithSize decoder bytes of
-  Left err -> Left $ DecodingErrorCBOR err
-  Right (rest, consumed, a) -> return (rest, (LBS.take (fromIntegral consumed) bytes, a))
-
--- | [(spec)](https://www.w3.org/TR/webauthn-2/#authenticator-data)
-decodeAuthenticatorData ::
-  forall t.
-  SingI t =>
-  BS.ByteString ->
-  Either DecodingError (M.AuthenticatorData t)
-decodeAuthenticatorData adRawData = do
-  let bytes = LBS.fromStrict adRawData
-  -- https://www.w3.org/TR/webauthn-2/#rpidhash
-  (bytes, adRpIdHash) <-
-    second (M.RpIdHash . fromJust . Hash.digestFromByteString)
-      <$> runBinary (Binary.getByteString 32) bytes
-
-  -- https://www.w3.org/TR/webauthn-2/#flags
-  (bytes, bitFlags) <-
-    runBinary Binary.getWord8 bytes
-  let adFlags =
-        M.AuthenticatorDataFlags
-          { adfUserPresent = Bits.testBit bitFlags 0,
-            adfUserVerified = Bits.testBit bitFlags 2
-          }
-
-  -- https://www.w3.org/TR/webauthn-2/#signcount
-  (bytes, adSignCount) <-
-    second M.SignatureCounter
-      <$> runBinary Binary.getWord32be bytes
-
-  -- https://www.w3.org/TR/webauthn-2/#attestedcredentialdata
-  (bytes, adAttestedCredentialData) <- case (sing @t, Bits.testBit bitFlags 6) of
-    -- For [attestation signatures](https://www.w3.org/TR/webauthn-2/#attestation-signature),
-    -- the authenticator MUST set the AT [flag](https://www.w3.org/TR/webauthn-2/#flags)
-    -- and include the `[attestedCredentialData](https://www.w3.org/TR/webauthn-2/#attestedcredentialdata)`.
-    (SCreate, True) -> decodeAttestedCredentialData bytes
-    (SCreate, False) -> Left DecodingErrorExpectedAttestedCredentialData
-    -- For [assertion signatures](https://www.w3.org/TR/webauthn-2/#assertion-signature),
-    -- the AT [flag](https://www.w3.org/TR/webauthn-2/#flags) MUST NOT be set and the
-    -- `[attestedCredentialData](https://www.w3.org/TR/webauthn-2/#attestedcredentialdata)` MUST NOT be included.
-    (SGet, False) -> pure (bytes, M.NoAttestedCredentialData)
-    (SGet, True) -> Left DecodingErrorUnexpectedAttestedCredentialData
-
-  -- https://www.w3.org/TR/webauthn-2/#authdataextensions
-  (bytes, adExtensions) <-
-    if Bits.testBit bitFlags 7
-      then fmap Just <$> decodeExtensions bytes
-      else pure (bytes, Nothing)
-
-  if LBS.null bytes
-    then pure M.AuthenticatorData {..}
-    else Left $ DecodingErrorNotAllInputUsed bytes
-
-decodeAttestedCredentialData :: PartialBinaryDecoder (M.AttestedCredentialData 'M.Create)
-decodeAttestedCredentialData bytes = do
-  -- https://www.w3.org/TR/webauthn-2/#aaguid
-  (bytes, acdAaguid) <-
-    second M.AAGUID
-      <$> runBinary (Binary.getByteString 16) bytes
-
-  -- https://www.w3.org/TR/webauthn-2/#credentialidlength
-  (bytes, credentialLength) <-
-    runBinary Binary.getWord16be bytes
-
-  -- https://www.w3.org/TR/webauthn-2/#credentialid
-  (bytes, acdCredentialId) <-
-    second M.CredentialId
-      <$> runBinary (Binary.getByteString (fromIntegral credentialLength)) bytes
-
-  -- https://www.w3.org/TR/webauthn-2/#credentialpublickey
-  (bytes, (usedBytes, acdCredentialPublicKey)) <-
-    runCBOR decodePublicKey bytes
-  let acdCredentialPublicKeyBytes = M.PublicKeyBytes $ LBS.toStrict usedBytes
-
-  pure (bytes, M.AttestedCredentialData {..})
-
--- | [(spec)](https://www.w3.org/TR/webauthn-2/#authdataextensions)
-decodeExtensions :: PartialBinaryDecoder M.AuthenticatorExtensionOutputs
-decodeExtensions bytes = do
-  -- TODO
-  (bytes, (_, _extensions :: HashMap Text CBOR.Term)) <- runCBOR CBOR.decode bytes
-  pure (bytes, M.AuthenticatorExtensionOutputs {})
 
 -- | @'Decode' a@ indicates that the Haskell-specific type @a@ can be
 -- decoded from the more generic JavaScript type @'JS' a@ with the 'decode' function.
 class Convert a => Decode a where
-  decode :: JS a -> Either DecodingError a
-  default decode :: Coercible (JS a) a => JS a -> Either DecodingError a
+  decode :: JS a -> Either MD.DecodingError a
+  default decode :: Coercible (JS a) a => JS a -> Either MD.DecodingError a
   decode = pure . coerce
 
 -- | Like 'Decode', but with a 'decodeCreated' function that also takes a
@@ -227,7 +50,7 @@ class Convert a => Decode a where
 -- on the supported attestation formats. This function also throws a
 -- 'CreatedDecodingError' instead of a 'DecodingError.
 class Convert a => DecodeCreated a where
-  decodeCreated :: SupportedAttestationStatementFormats -> JS a -> Either CreatedDecodingError a
+  decodeCreated :: SupportedAttestationStatementFormats -> JS a -> Either MD.CreatedDecodingError a
 
 instance Decode a => Decode (Maybe a) where
   decode Nothing = pure Nothing
@@ -243,37 +66,13 @@ instance Decode M.AuthenticationExtensionsClientOutputs where
   -- TODO: Implement extension support
   decode _ = pure M.AuthenticationExtensionsClientOutputs {}
 
-instance SingI t => Decode (M.CollectedClientData t) where
-  decode (IDL.URLEncodedBase64 bytes) = do
-    -- https://www.w3.org/TR/webauthn-2/#collectedclientdata-json-compatible-serialization-of-client-data
-    JS.ClientDataJSON {..} <- first DecodingErrorClientDataJSON $ Aeson.eitherDecodeStrict bytes
-    -- [(spec)](https://www.w3.org/TR/webauthn-2/#dom-collectedclientdata-challenge)
-    -- This member contains the base64url encoding of the challenge provided by the
-    -- [Relying Party](https://www.w3.org/TR/webauthn-2/#relying-party). See the
-    -- [§ 13.4.3 Cryptographic Challenges](https://www.w3.org/TR/webauthn-2/#sctn-cryptographic-challenges)
-    -- security consideration.
-    challenge <- first DecodingErrorClientDataChallenge $ Base64.decode (Text.encodeUtf8 challenge)
-    -- [(spec)](https://www.w3.org/TR/webauthn-2/#dom-collectedclientdata-type)
-    -- This member contains the string "webauthn.create" when creating new credentials,
-    -- and "webauthn.get" when getting an assertion from an existing credential.
-    -- The purpose of this member is to prevent certain types of signature confusion
-    -- attacks (where an attacker substitutes one legitimate signature for another).
-    let expectedType = case sing @t of
-          SCreate -> "webauthn.create"
-          SGet -> "webauthn.get"
-    unless (littype == expectedType) $ Left (DecodingErrorUnexpectedWebauthnType expectedType littype)
-    pure
-      M.CollectedClientData
-        { ccdChallenge = M.Challenge challenge,
-          ccdOrigin = M.Origin origin,
-          ccdCrossOrigin = crossOrigin,
-          ccdHash = M.ClientDataHash $ Hash.hash bytes
-        }
+instance SingI t => Decode (M.CollectedClientData t 'True) where
+  decode (IDL.URLEncodedBase64 bytes) = MD.decodeCollectedClientData bytes
 
-instance Decode (M.AuthenticatorData 'M.Get) where
-  decode (IDL.URLEncodedBase64 bytes) = decodeAuthenticatorData bytes
+instance Decode (M.AuthenticatorData 'M.Get 'True) where
+  decode (IDL.URLEncodedBase64 bytes) = MD.decodeAuthenticatorData bytes
 
-instance Decode (M.AuthenticatorResponse 'M.Get) where
+instance Decode (M.AuthenticatorResponse 'M.Get 'True) where
   decode JS.AuthenticatorAssertionResponse {..} = do
     argClientData <- decode clientDataJSON
     argAuthenticatorData <- decode authenticatorData
@@ -281,7 +80,7 @@ instance Decode (M.AuthenticatorResponse 'M.Get) where
     argUserHandle <- decode userHandle
     pure $ M.AuthenticatorAssertionResponse {..}
 
-instance Decode (M.PublicKeyCredential 'M.Get) where
+instance Decode (M.PublicKeyCredential 'M.Get 'True) where
   decode JS.PublicKeyCredential {..} = do
     pkcIdentifier <- decode rawId
     pkcResponse <- decode response
@@ -316,7 +115,7 @@ instance Decode PublicKey.COSEAlgorithmIdentifier where
   -- assertion/attestation. We implement the check here to go to a Haskell
   -- type. Erring on the side of caution by failing to parse if an unsupported
   -- alg was encountered.
-  decode n = maybe (Left $ DecodingErrorUnexpectedAlgorithmIdentifier n) Right $ PublicKey.toAlg n
+  decode n = maybe (Left $ MD.DecodingErrorUnexpectedAlgorithmIdentifier n) Right $ PublicKey.toAlg n
 
 instance Decode M.Timeout
 
@@ -339,7 +138,7 @@ instance Decode [M.PublicKeyCredentialDescriptor] where
   decode Nothing = pure []
   decode (Just xs) = catMaybes <$> traverse decodeDescriptor xs
     where
-      decodeDescriptor :: JS.PublicKeyCredentialDescriptor -> Either DecodingError (Maybe M.PublicKeyCredentialDescriptor)
+      decodeDescriptor :: JS.PublicKeyCredentialDescriptor -> Either MD.DecodingError (Maybe M.PublicKeyCredentialDescriptor)
       decodeDescriptor JS.PublicKeyCredentialDescriptor {littype = "public-key", id, transports} = do
         let pkcdTyp = M.PublicKeyCredentialTypePublicKey
         pkcdId <- decode id
@@ -402,7 +201,7 @@ instance Decode M.AttestationConveyancePreference where
 instance Decode [M.PublicKeyCredentialParameters] where
   decode xs = catMaybes <$> traverse decodeParam xs
     where
-      decodeParam :: JS.PublicKeyCredentialParameters -> Either DecodingError (Maybe M.PublicKeyCredentialParameters)
+      decodeParam :: JS.PublicKeyCredentialParameters -> Either MD.DecodingError (Maybe M.PublicKeyCredentialParameters)
       decodeParam JS.PublicKeyCredentialParameters {littype = "public-key", alg} = do
         let pkcpTyp = M.PublicKeyCredentialTypePublicKey
         pkcpAlg <- decode alg
@@ -435,39 +234,23 @@ instance Decode (M.PublicKeyCredentialOptions 'M.Get) where
     pure $ M.PublicKeyCredentialRequestOptions {..}
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#sctn-generating-an-attestation-object)
-instance DecodeCreated M.AttestationObject where
-  decodeCreated supportedFormats (IDL.URLEncodedBase64 bytes) = do
-    map :: HashMap Text CBOR.Term <- first (CreatedDecodingErrorCommon . DecodingErrorCBOR) $ CBOR.deserialiseOrFail $ LBS.fromStrict bytes
-    case (map !? "authData", map !? "fmt", map !? "attStmt") of
-      (Just (CBOR.TBytes authDataBytes), Just (CBOR.TString fmt), Just (CBOR.TMap attStmtPairs)) -> do
-        aoAuthData <- first CreatedDecodingErrorCommon $ decodeAuthenticatorData authDataBytes
+instance DecodeCreated (M.AttestationObject 'True) where
+  decodeCreated supportedFormats (IDL.URLEncodedBase64 bytes) =
+    MD.decodeAttestationObject supportedFormats bytes
 
-        case sasfLookup fmt supportedFormats of
-          Nothing -> Left $ CreatedDecodingErrorUnknownAttestationStatementFormat fmt
-          Just (SomeAttestationStatementFormat aoFmt) -> do
-            attStmtMap <-
-              HashMap.fromList <$> forM attStmtPairs \case
-                (CBOR.TString text, term) -> pure (text, term)
-                (nonString, _) -> Left $ CreatedDecodingErrorUnexpectedAttestationStatementKey nonString
-            aoAttStmt <-
-              first (CreatedDecodingErrorAttestationStatement . SomeException) $
-                asfDecode aoFmt attStmtMap
-            pure $ M.AttestationObject {..}
-      _ -> Left $ CreatedDecodingErrorUnexpectedAttestationObjectValues map
-
-instance DecodeCreated (M.AuthenticatorResponse 'M.Create) where
+instance DecodeCreated (M.AuthenticatorResponse 'M.Create 'True) where
   decodeCreated asfMap JS.AuthenticatorAttestationResponse {..} = do
-    arcClientData <- first CreatedDecodingErrorCommon $ decode clientDataJSON
+    arcClientData <- first MD.CreatedDecodingErrorCommon $ decode clientDataJSON
     arcAttestationObject <- decodeCreated asfMap attestationObject
     -- TODO: The webauthn-json library doesn't currently pass the transports
     let arcTransports = Set.empty
     pure $ M.AuthenticatorAttestationResponse {..}
 
-instance DecodeCreated (M.PublicKeyCredential 'M.Create) where
+instance DecodeCreated (M.PublicKeyCredential 'M.Create 'True) where
   decodeCreated asfMap JS.PublicKeyCredential {..} = do
-    pkcIdentifier <- first CreatedDecodingErrorCommon $ decode rawId
+    pkcIdentifier <- first MD.CreatedDecodingErrorCommon $ decode rawId
     pkcResponse <- decodeCreated asfMap response
-    pkcClientExtensionResults <- first CreatedDecodingErrorCommon $ decode clientExtensionResults
+    pkcClientExtensionResults <- first MD.CreatedDecodingErrorCommon $ decode clientExtensionResults
     pure $ M.PublicKeyCredential {..}
 
 -- | Decodes a 'JS.CreatedPublicKeyCredential' result, corresponding to the
@@ -477,7 +260,7 @@ instance DecodeCreated (M.PublicKeyCredential 'M.Create) where
 decodeCreatedPublicKeyCredential ::
   SupportedAttestationStatementFormats ->
   JS.CreatedPublicKeyCredential ->
-  Either CreatedDecodingError (M.PublicKeyCredential 'M.Create)
+  Either MD.CreatedDecodingError (M.PublicKeyCredential 'M.Create 'True)
 decodeCreatedPublicKeyCredential = decodeCreated
 
 -- | Decodes a 'JS.RequestedPublicKeyCredential' result, corresponding to the
@@ -486,23 +269,15 @@ decodeCreatedPublicKeyCredential = decodeCreated
 -- method while [Verifying an Authentication Assertion](https://www.w3.org/TR/webauthn-2/#sctn-verifying-assertion)
 decodeRequestedPublicKeyCredential ::
   JS.RequestedPublicKeyCredential ->
-  Either DecodingError (M.PublicKeyCredential 'M.Get)
+  Either MD.DecodingError (M.PublicKeyCredential 'M.Get 'True)
 decodeRequestedPublicKeyCredential = decode
 
 decodePublicKeyCredentialCreationOptions ::
   JS.PublicKeyCredentialCreationOptions ->
-  Either DecodingError (M.PublicKeyCredentialOptions 'M.Create)
+  Either MD.DecodingError (M.PublicKeyCredentialOptions 'M.Create)
 decodePublicKeyCredentialCreationOptions = decode
 
 decodePublicKeyCredentialRequestOptions ::
   JS.PublicKeyCredentialRequestOptions ->
-  Either DecodingError (M.PublicKeyCredentialOptions 'M.Get)
+  Either MD.DecodingError (M.PublicKeyCredentialOptions 'M.Get)
 decodePublicKeyCredentialRequestOptions = decode
-
--- | [(spec)](https://www.w3.org/TR/webauthn-2/#dictionary-client-data)
-decodeCreateCollectedClientData :: IDL.ArrayBuffer -> Either DecodingError (M.CollectedClientData 'M.Create)
-decodeCreateCollectedClientData = decode
-
--- | [(spec)](https://www.w3.org/TR/webauthn-2/#dictionary-client-data)
-decodeGetCollectedClientData :: IDL.ArrayBuffer -> Either DecodingError (M.CollectedClientData 'M.Get)
-decodeGetCollectedClientData = decode

--- a/fido/Crypto/Fido2/Model/JavaScript/Encoding.hs
+++ b/fido/Crypto/Fido2/Model/JavaScript/Encoding.hs
@@ -19,21 +19,15 @@ module Crypto.Fido2.Model.JavaScript.Encoding
   )
 where
 
-import qualified Codec.CBOR.Term as CBOR
-import qualified Codec.CBOR.Write as CBOR
 import qualified Crypto.Fido2.Model as M
+import qualified Crypto.Fido2.Model.Binary.Encoding as ME
 import qualified Crypto.Fido2.Model.JavaScript as JS
 import Crypto.Fido2.Model.JavaScript.Types (Convert (JS))
-import qualified Crypto.Fido2.Model.JavaScript.Types as JS
-import Crypto.Fido2.Model.WebauthnType (SWebauthnType (SCreate, SGet), SingI (sing))
+import Crypto.Fido2.Model.WebauthnType (SingI)
 import qualified Crypto.Fido2.PublicKey as PublicKey
 import qualified Crypto.Fido2.WebIDL as IDL
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString.Base64.URL as Base64
-import Data.ByteString.Lazy (toStrict)
 import Data.Coerce (Coercible, coerce)
 import qualified Data.Map as Map
-import qualified Data.Text.Encoding as Text
 
 -- | @'Encode' hs@ indicates that the Haskell-specific type @hs@ can be
 -- encoded to the more generic JavaScript type @'JS' hs@ with the 'encode' function.
@@ -184,7 +178,7 @@ instance Encode (M.PublicKeyCredentialOptions 'M.Get) where
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#iface-pkcredential)
 -- Encodes the PublicKeyCredential for attestation, this instance is mostly used in the tests where we emulate the
 -- of the client.
-instance Encode (M.PublicKeyCredential 'M.Create) where
+instance Encode (M.PublicKeyCredential 'M.Create 'True) where
   encode M.PublicKeyCredential {..} =
     JS.PublicKeyCredential
       { rawId = encode pkcIdentifier,
@@ -194,30 +188,19 @@ instance Encode (M.PublicKeyCredential 'M.Create) where
       }
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dom-authenticatorresponse-clientdatajson)
-instance SingI t => Encode (M.CollectedClientData t) where
-  encode M.CollectedClientData {..} =
-    let typ = case sing @t of
-          SCreate -> "webauthn.create"
-          SGet -> "webauthn.get"
-     in IDL.URLEncodedBase64 . toStrict $
-          Aeson.encode
-            JS.ClientDataJSON
-              { littype = typ,
-                challenge = Text.decodeUtf8 . Base64.encode $ M.unChallenge ccdChallenge,
-                origin = M.unOrigin ccdOrigin,
-                crossOrigin = ccdCrossOrigin
-              }
+instance SingI t => Encode (M.CollectedClientData t 'True) where
+  encode ccd = IDL.URLEncodedBase64 $ ME.encodeCollectedClientData ccd
 
-instance Encode (M.AuthenticatorResponse 'M.Get) where
+instance Encode (M.AuthenticatorResponse 'M.Get 'True) where
   encode M.AuthenticatorAssertionResponse {..} =
     JS.AuthenticatorAssertionResponse
       { clientDataJSON = encode argClientData,
-        authenticatorData = IDL.URLEncodedBase64 $ M.adRawData argAuthenticatorData,
+        authenticatorData = IDL.URLEncodedBase64 $ M.unRaw $ M.adRawData argAuthenticatorData,
         signature = IDL.URLEncodedBase64 $ M.unAssertionSignature argSignature,
         userHandle = IDL.URLEncodedBase64 . M.unUserHandle <$> argUserHandle
       }
 
-instance Encode (M.PublicKeyCredential 'M.Get) where
+instance Encode (M.PublicKeyCredential 'M.Get 'True) where
   encode M.PublicKeyCredential {..} =
     JS.PublicKeyCredential
       { rawId = encode pkcIdentifier,
@@ -227,7 +210,7 @@ instance Encode (M.PublicKeyCredential 'M.Get) where
       }
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#iface-authenticatorresponse)
-instance Encode (M.AuthenticatorResponse 'M.Create) where
+instance Encode (M.AuthenticatorResponse 'M.Create 'True) where
   encode M.AuthenticatorAttestationResponse {..} =
     JS.AuthenticatorAttestationResponse
       { clientDataJSON = encode arcClientData,
@@ -235,17 +218,8 @@ instance Encode (M.AuthenticatorResponse 'M.Create) where
       }
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dom-authenticatorattestationresponse-attestationobject)
-instance Encode M.AttestationObject where
-  encode M.AttestationObject {..} =
-    IDL.URLEncodedBase64 . CBOR.toStrictByteString $ CBOR.encodeTerm term
-    where
-      term :: CBOR.Term
-      term =
-        CBOR.TMap
-          [ (CBOR.TString "authData", CBOR.TBytes $ M.adRawData aoAuthData),
-            (CBOR.TString "fmt", CBOR.TString $ M.asfIdentifier aoFmt),
-            (CBOR.TString "attStmt", M.asfEncode aoFmt aoAttStmt)
-          ]
+instance Encode (M.AttestationObject 'True) where
+  encode ao = IDL.URLEncodedBase64 $ ME.encodeAttestationObject ao
 
 -- | Encodes a 'JS.PublicKeyCredentialCreationOptions', corresponding to the
 -- [`PublicKeyCredentialCreationOptions` dictionary](https://www.w3.org/TR/webauthn-2/#dictionary-makecredentialoptions)
@@ -268,11 +242,11 @@ encodePublicKeyCredentialRequestOptions = encode
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#iface-pkcredential)
 -- Encodes the PublicKeyCredential for attestation, this function is mostly used in the tests where we emulate the
 -- of the client.
-encodeCreatedPublicKeyCredential :: M.PublicKeyCredential 'M.Create -> JS.CreatedPublicKeyCredential
+encodeCreatedPublicKeyCredential :: M.PublicKeyCredential 'M.Create 'True -> JS.CreatedPublicKeyCredential
 encodeCreatedPublicKeyCredential = encode
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#iface-pkcredential)
 -- Encodes the PublicKeyCredential for assertion, this function is mostly used in the tests where we emulate the
 -- of the client.
-encodeRequestedPublicKeyCredential :: M.PublicKeyCredential 'M.Get -> JS.RequestedPublicKeyCredential
+encodeRequestedPublicKeyCredential :: M.PublicKeyCredential 'M.Get 'True -> JS.RequestedPublicKeyCredential
 encodeRequestedPublicKeyCredential = encode

--- a/fido/Crypto/Fido2/Model/JavaScript/Types.hs
+++ b/fido/Crypto/Fido2/Model/JavaScript/Types.hs
@@ -4,11 +4,9 @@
 
 module Crypto.Fido2.Model.JavaScript.Types
   ( Convert (..),
-    ClientDataJSON (..),
   )
 where
 
-import Crypto.Fido2.EncodingUtils (CustomJSON (CustomJSON), JSONEncoding)
 import qualified Crypto.Fido2.Model as M
 import qualified Crypto.Fido2.Model.JavaScript as JS
 import qualified Crypto.Fido2.PublicKey as PublicKey
@@ -17,31 +15,6 @@ import qualified Data.Aeson as Aeson
 import Data.Kind (Type)
 import Data.Map (Map)
 import Data.Text (Text)
-import GHC.Generics (Generic)
-
--- | [(spec)](https://www.w3.org/TR/webauthn-2/#dictionary-client-data)
--- Intermediate type used to extract the JSON structure stored in the
--- CBOR-encoded [clientDataJSON](https://www.w3.org/TR/webauthn-2/#dom-authenticatorresponse-clientdatajson).
--- NOTE: Do not rely on the ToJSON instance of this type, it is not implemented according to spec.
-data ClientDataJSON = ClientDataJSON
-  { littype :: IDL.DOMString,
-    challenge :: IDL.DOMString,
-    origin :: IDL.DOMString,
-    crossOrigin :: Maybe Bool
-    -- TODO
-    -- tokenBinding :: Maybe TokenBinding
-  }
-  deriving (Generic)
-  -- Note: Encoding can NOT be derived automatically, and most likely not even
-  -- be provided correctly with the Aeson.ToJSON class, because it is only a
-  -- JSON-_compatible_ encoding, but it also contains some extra structure
-  -- allowing for verification without a full JSON parser
-  -- See <https://www.w3.org/TR/webauthn-2/#clientdatajson-serialization>
-  -- TODO/FIXME: As described above the ToJSON instance should not be derived,
-  -- but implemented manually using the description provided in the specification.
-  -- For now the ToJSON instance is only used for tests so it suffices, but
-  -- library users should not rely on it.
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding ClientDataJSON
 
 -- | @'Convert' hs@ indicates that the Haskell-specific type @hs@ has a more
 -- general JavaScript-specific type associated with it, which can be accessed with 'JS'.
@@ -123,29 +96,29 @@ instance Convert (M.PublicKeyCredentialOptions 'M.Create) where
 instance Convert (M.PublicKeyCredentialOptions 'M.Get) where
   type JS (M.PublicKeyCredentialOptions 'M.Get) = JS.PublicKeyCredentialRequestOptions
 
-instance Convert (M.PublicKeyCredential 'M.Create) where
-  type JS (M.PublicKeyCredential 'M.Create) = JS.PublicKeyCredential JS.AuthenticatorAttestationResponse
+instance Convert (M.PublicKeyCredential 'M.Create raw) where
+  type JS (M.PublicKeyCredential 'M.Create raw) = JS.PublicKeyCredential JS.AuthenticatorAttestationResponse
 
-instance Convert (M.AuthenticatorResponse 'M.Create) where
-  type JS (M.AuthenticatorResponse 'M.Create) = JS.AuthenticatorAttestationResponse
+instance Convert (M.AuthenticatorResponse 'M.Create raw) where
+  type JS (M.AuthenticatorResponse 'M.Create raw) = JS.AuthenticatorAttestationResponse
 
-instance Convert (M.PublicKeyCredential 'M.Get) where
-  type JS (M.PublicKeyCredential 'M.Get) = JS.PublicKeyCredential JS.AuthenticatorAssertionResponse
+instance Convert (M.PublicKeyCredential 'M.Get raw) where
+  type JS (M.PublicKeyCredential 'M.Get raw) = JS.PublicKeyCredential JS.AuthenticatorAssertionResponse
 
-instance Convert (M.AuthenticatorResponse 'M.Get) where
-  type JS (M.AuthenticatorResponse 'M.Get) = JS.AuthenticatorAssertionResponse
+instance Convert (M.AuthenticatorResponse 'M.Get raw) where
+  type JS (M.AuthenticatorResponse 'M.Get raw) = JS.AuthenticatorAssertionResponse
 
 instance Convert M.AuthenticationExtensionsClientOutputs where
   type JS M.AuthenticationExtensionsClientOutputs = Map Text Aeson.Value
 
-instance Convert (M.CollectedClientData t) where
-  type JS (M.CollectedClientData t) = IDL.ArrayBuffer
+instance Convert (M.CollectedClientData t 'True) where
+  type JS (M.CollectedClientData t 'True) = IDL.ArrayBuffer
 
-instance Convert M.AttestationObject where
-  type JS M.AttestationObject = IDL.ArrayBuffer
+instance Convert (M.AttestationObject raw) where
+  type JS (M.AttestationObject raw) = IDL.ArrayBuffer
 
 instance Convert M.AssertionSignature where
   type JS M.AssertionSignature = IDL.ArrayBuffer
 
-instance Convert (M.AuthenticatorData 'M.Get) where
-  type JS (M.AuthenticatorData 'M.Get) = IDL.ArrayBuffer
+instance Convert (M.AuthenticatorData 'M.Get raw) where
+  type JS (M.AuthenticatorData 'M.Get raw) = IDL.ArrayBuffer

--- a/fido/Crypto/Fido2/Operations/Attestation/AndroidKey.hs
+++ b/fido/Crypto/Fido2/Operations/Attestation/AndroidKey.hs
@@ -226,7 +226,7 @@ instance M.AttestationStatementFormat Format where
 
   type AttStmtVerificationError Format = VerificationError
 
-  asfVerify _ Statement {sig, x5c, attExt, pubKey} M.AuthenticatorData {adRawData, adAttestedCredentialData} clientDataHash = do
+  asfVerify _ Statement {sig, x5c, attExt, pubKey} M.AuthenticatorData {adRawData = M.WithRaw rawData, adAttestedCredentialData} clientDataHash = do
     -- 1. Verify that attStmt is valid CBOR conforming to the syntax defined above and perform CBOR decoding on it to
     -- extract the contained fields.
     -- NOTE: The validity of the data is already checked during decoding.
@@ -234,7 +234,7 @@ instance M.AttestationStatementFormat Format where
     -- 2. Verify that sig is a valid signature over the concatenation of authenticatorData and clientDataHash using the
     -- public key in the first certificate in x5c with the algorithm specified in alg.
     -- TODO: Maybe use verifyX509Sig like in Packed.hs
-    let signedData = adRawData <> convert (M.unClientDataHash clientDataHash)
+    let signedData = rawData <> convert (M.unClientDataHash clientDataHash)
     unless (PublicKey.verify pubKey signedData sig) . Left $ undefined
 
     -- 3. Verify that the public key in the first certificate in x5c matches the credentialPublicKey in the

--- a/fido/Crypto/Fido2/Operations/Attestation/Apple.hs
+++ b/fido/Crypto/Fido2/Operations/Attestation/Apple.hs
@@ -134,7 +134,7 @@ instance M.AttestationStatementFormat Format where
 
       -- 2. Concatenate authenticatorData and clientDataHash to form
       -- nonceToHash.
-      let nonceToHash = adRawData <> BA.convert (M.unClientDataHash clientDataHash)
+      let nonceToHash = M.unRaw adRawData <> BA.convert (M.unClientDataHash clientDataHash)
 
       -- 3. Perform SHA-256 hash of nonceToHash to produce nonce.
       let nonce :: Digest SHA256 = hash nonceToHash

--- a/fido/Crypto/Fido2/Operations/Attestation/Packed.hs
+++ b/fido/Crypto/Fido2/Operations/Attestation/Packed.hs
@@ -123,9 +123,9 @@ instance M.AttestationStatementFormat Format where
   asfVerify
     _
     Statement {alg = stmtAlg, sig = stmtSig, x5c = stmtx5c}
-    M.AuthenticatorData {M.adRawData, M.adAttestedCredentialData = credData}
+    M.AuthenticatorData {M.adRawData = M.WithRaw rawData, M.adAttestedCredentialData = credData}
     clientDataHash = do
-      let signedData = adRawData <> convert (M.unClientDataHash clientDataHash)
+      let signedData = rawData <> convert (M.unClientDataHash clientDataHash)
       case stmtx5c of
         -- Self attestation
         Nothing -> do

--- a/fido2.cabal
+++ b/fido2.cabal
@@ -74,6 +74,8 @@ library
     Crypto.Fido2.UAF,
     Crypto.Fido2.Registry,
     Crypto.Fido2.Model,
+    Crypto.Fido2.Model.Binary.Decoding,
+    Crypto.Fido2.Model.Binary.Encoding,
     Crypto.Fido2.Model.JavaScript,
     Crypto.Fido2.Model.JavaScript.Decoding,
     Crypto.Fido2.Model.JavaScript.Encoding,

--- a/fido2.cabal
+++ b/fido2.cabal
@@ -128,6 +128,7 @@ test-suite tests
     MetadataSpec,
     Spec.Types,
     Spec.Util,
+    Encoding,
     Emulation.Client,
     Emulation.Client.PrivateKey,
     Emulation.Authenticator,

--- a/server/src/PendingOps.hs
+++ b/server/src/PendingOps.hs
@@ -143,11 +143,11 @@ insertPendingOptions pendingOps = case sing @t of
 -- This deletes the options from memory again. If the challenge is expired an error is returned
 -- This function can be used for both register and login webauthn operations
 getPendingOptions ::
-  forall t.
+  forall t raw.
   SingI t =>
   PendingOps ->
   -- The credential that was received as a reply
-  M.PublicKeyCredential t ->
+  M.PublicKeyCredential t raw ->
   IO (Either String (M.PublicKeyCredentialOptions t))
 getPendingOptions pending cred = case sing @t of
   -- We extract the challenge from the response credential that was sent back

--- a/tests/Emulation/Client.hs
+++ b/tests/Emulation/Client.hs
@@ -87,7 +87,7 @@ clientAttestation M.PublicKeyCredentialCreationOptions {..} AnnotatedOrigin {..}
           M.CollectedClientData
             { ccdChallenge = challenge,
               ccdOrigin = aoOrigin,
-              ccdCrossOrigin = Nothing,
+              ccdCrossOrigin = False,
               ccdRawData = M.NoRaw
             }
       clientDataHash =
@@ -112,10 +112,7 @@ clientAttestation M.PublicKeyCredentialCreationOptions {..} AnnotatedOrigin {..}
             M.pkcResponse =
               M.AuthenticatorAttestationResponse
                 { M.arcClientData = clientData,
-                  M.arcAttestationObject = attestationObject,
-                  -- Currently ignored by the library
-                  -- TODO: Policy
-                  M.arcTransports = Set.empty
+                  M.arcAttestationObject = attestationObject
                 },
             M.pkcClientExtensionResults = M.AuthenticationExtensionsClientOutputs {}
           }
@@ -146,7 +143,7 @@ clientAssertion M.PublicKeyCredentialRequestOptions {..} AnnotatedOrigin {..} co
           M.CollectedClientData
             { ccdChallenge = challenge,
               ccdOrigin = aoOrigin,
-              ccdCrossOrigin = Nothing,
+              ccdCrossOrigin = False,
               ccdRawData = M.NoRaw
             }
       clientDataHash = M.ClientDataHash $ hash $ M.unRaw $ M.ccdRawData clientData

--- a/tests/Encoding.hs
+++ b/tests/Encoding.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE DataKinds #-}
+
+module Encoding (spec) where
+
+import qualified Crypto.Fido2.Model as M
+import Crypto.Fido2.Model.Binary.Encoding (encodeRawPublicKeyCredential)
+import Crypto.Fido2.Model.JavaScript.Decoding (decodeCreatedPublicKeyCredential, decodePublicKeyCredentialCreationOptions, decodePublicKeyCredentialRequestOptions, decodeRequestedPublicKeyCredential)
+import Crypto.Fido2.Model.JavaScript.Encoding (encodeCreatedPublicKeyCredential, encodePublicKeyCredentialCreationOptions, encodePublicKeyCredentialRequestOptions, encodeRequestedPublicKeyCredential)
+import Crypto.Fido2.Operations.Attestation (allSupportedFormats)
+import Spec.Types ()
+import Test.Hspec (Expectation, SpecWith, describe, expectationFailure, shouldBe)
+import Test.Hspec.QuickCheck (prop)
+
+spec :: SpecWith ()
+spec = do
+  describe "PublicKeyCredentialCreationOptions" $
+    prop "can be roundtripped" prop_creationOptionsRoundtrip
+  describe "PublicKeyCredentialRequestOptions" $
+    prop "can be roundtripped" prop_requestOptionsRoundtrip
+  describe "CreatedPublicKeyCredential" $
+    prop "can be roundtripped" prop_createdCredentialRoundtrip
+  describe "RequestedPublicKeyCredential" $
+    prop "can be roundtripped" prop_requestedCredentialRoundtrip
+
+prop_creationOptionsRoundtrip :: M.PublicKeyCredentialOptions 'M.Create -> Expectation
+prop_creationOptionsRoundtrip options = do
+  let encoded = encodePublicKeyCredentialCreationOptions options
+  case decodePublicKeyCredentialCreationOptions encoded of
+    Right decoded -> decoded `shouldBe` options
+    Left err -> expectationFailure $ show err
+
+prop_requestOptionsRoundtrip :: M.PublicKeyCredentialOptions 'M.Get -> Expectation
+prop_requestOptionsRoundtrip options = do
+  let encoded = encodePublicKeyCredentialRequestOptions options
+  case decodePublicKeyCredentialRequestOptions encoded of
+    Right decoded -> decoded `shouldBe` options
+    Left err -> expectationFailure $ show err
+
+prop_createdCredentialRoundtrip :: M.PublicKeyCredential 'M.Create 'False -> Expectation
+prop_createdCredentialRoundtrip options = do
+  let withRaw = encodeRawPublicKeyCredential options
+      encoded = encodeCreatedPublicKeyCredential withRaw
+  case decodeCreatedPublicKeyCredential allSupportedFormats encoded of
+    Right decoded -> do
+      decoded `shouldBe` withRaw
+    Left err -> expectationFailure $ show err
+
+prop_requestedCredentialRoundtrip :: M.PublicKeyCredential 'M.Get 'False -> Expectation
+prop_requestedCredentialRoundtrip options = do
+  let withRaw = encodeRawPublicKeyCredential options
+      encoded = encodeRequestedPublicKeyCredential withRaw
+  case decodeRequestedPublicKeyCredential encoded of
+    Right decoded -> do
+      decoded `shouldBe` withRaw
+    Left err -> expectationFailure $ show err

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -177,9 +177,9 @@ main = Hspec.hspec $ do
                   pkCredential
         registerResult `shouldSatisfy` isExpectedAttestationResponse pkCredential options
 
-isExpectedAttestationResponse :: M.PublicKeyCredential 'M.Create -> M.PublicKeyCredentialOptions 'M.Create -> Either (NonEmpty AttestationError) Common.CredentialEntry -> Bool
+isExpectedAttestationResponse :: M.PublicKeyCredential 'M.Create 'True -> M.PublicKeyCredentialOptions 'M.Create -> Either (NonEmpty AttestationError) Common.CredentialEntry -> Bool
 isExpectedAttestationResponse _ _ (Left _) = False -- We should never receive errors
-isExpectedAttestationResponse M.PublicKeyCredential {..} M.PublicKeyCredentialCreationOptions {..} (Right ce@Common.CredentialEntry {..}) =
+isExpectedAttestationResponse M.PublicKeyCredential {..} M.PublicKeyCredentialCreationOptions {..} (Right ce) =
   ce == expectedCredentialEntry
   where
     expectedCredentialEntry :: Common.CredentialEntry
@@ -187,11 +187,16 @@ isExpectedAttestationResponse M.PublicKeyCredential {..} M.PublicKeyCredentialCr
       Common.CredentialEntry
         { ceCredentialId = pkcIdentifier,
           ceUserHandle = M.pkcueId pkcocUser,
-          cePublicKeyBytes = M.acdCredentialPublicKeyBytes . M.adAttestedCredentialData . M.aoAuthData $ M.arcAttestationObject pkcResponse,
+          cePublicKeyBytes =
+            M.PublicKeyBytes . M.unRaw
+              . M.acdCredentialPublicKeyBytes
+              . M.adAttestedCredentialData
+              . M.aoAuthData
+              $ M.arcAttestationObject pkcResponse,
           ceSignCounter = M.adSignCount . M.aoAuthData $ M.arcAttestationObject pkcResponse
         }
 
-defaultPublicKeyCredentialCreationOptions :: M.PublicKeyCredential 'M.Create -> M.PublicKeyCredentialOptions 'M.Create
+defaultPublicKeyCredentialCreationOptions :: M.PublicKeyCredential 'M.Create raw -> M.PublicKeyCredentialOptions 'M.Create
 defaultPublicKeyCredentialCreationOptions pkc =
   M.PublicKeyCredentialCreationOptions
     { M.pkcocRp =
@@ -219,7 +224,7 @@ defaultPublicKeyCredentialCreationOptions pkc =
       M.pkcocExtensions = Nothing
     }
 
-defaultPublicKeyCredentialRequestOptions :: M.PublicKeyCredential 'M.Get -> M.PublicKeyCredentialOptions 'M.Get
+defaultPublicKeyCredentialRequestOptions :: M.PublicKeyCredential 'M.Get raw -> M.PublicKeyCredentialOptions 'M.Get
 defaultPublicKeyCredentialRequestOptions pkc =
   M.PublicKeyCredentialRequestOptions
     { M.pkcogChallenge = M.ccdChallenge . M.argClientData $ M.pkcResponse pkc,

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -25,6 +25,7 @@ import Data.Foldable (for_)
 import Data.List.NonEmpty (NonEmpty)
 import Data.Validation (toEither)
 import qualified Emulation.Client as Client
+import qualified Encoding
 import GHC.Stack (HasCallStack)
 import qualified MetadataSpec
 import qualified PublicKeySpec
@@ -75,6 +76,9 @@ main = Hspec.hspec $ do
   describe
     "Client Emulation"
     Client.spec
+  describe
+    "Encoding"
+    Encoding.spec
   describe "RegisterAndLogin" $
     it "tests whether the fixed register and login responses are matching" $
       do

--- a/tests/Spec/Types.hs
+++ b/tests/Spec/Types.hs
@@ -34,13 +34,16 @@ instance Arbitrary M.UserVerificationRequirement where
 instance Arbitrary M.AttestationConveyancePreference where
   arbitrary = arbitraryBoundedEnum
 
-instance Arbitrary (M.AuthenticatorResponse 'M.Create) where
+instance Arbitrary (M.AuthenticatorResponse 'M.Create 'False) where
   arbitrary = M.AuthenticatorAttestationResponse <$> arbitrary <*> arbitrary <*> arbitrary
 
-instance Arbitrary (M.CollectedClientData t) where
+instance Arbitrary (M.RawField 'False) where
+  arbitrary = pure M.NoRaw
+
+instance Arbitrary (M.CollectedClientData t 'False) where
   arbitrary = M.CollectedClientData <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
 
-instance Arbitrary M.AttestationObject where
+instance Arbitrary (M.AttestationObject 'False) where
   arbitrary = do
     aoAuthData <- arbitrary
     ArbitraryAttestationStatementFormat aoFmt <- arbitrary
@@ -65,7 +68,7 @@ instance Arbitrary ArbitraryAttestationStatementFormat where
 instance Arbitrary M.SignatureCounter where
   arbitrary = M.SignatureCounter <$> arbitrary
 
-instance SingI t => Arbitrary (M.AuthenticatorData t) where
+instance SingI t => Arbitrary (M.AuthenticatorData t 'False) where
   arbitrary = M.AuthenticatorData <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
 
 instance Arbitrary M.Challenge where
@@ -83,7 +86,7 @@ instance Arbitrary M.RpIdHash where
 instance Arbitrary M.AuthenticatorDataFlags where
   arbitrary = M.AuthenticatorDataFlags <$> arbitrary <*> arbitrary
 
-instance SingI t => Arbitrary (M.AttestedCredentialData t) where
+instance SingI t => Arbitrary (M.AttestedCredentialData t raw) where
   arbitrary = case sing @t of
     SCreate -> M.AttestedCredentialData <$> arbitrary <*> arbitrary <*> arbitrary <*> undefined
     SGet -> pure M.NoAttestedCredentialData


### PR DESCRIPTION
*   Raw model fields and full encoding support
    
    This commit extends the model with a "raw field" abstraction, which
    allows parametrizing the fully-decoded model by whether some fields
    contain the raw encoded data or not.
    
    This makes a lot of things nicer:
    - We can now have a function that turns model types without the raw
      fields into one that does, but doesn't do any other encoding.
    - We can generate well-behaved Arbitrary instances for the model without
      the raw fields
    - The above two points combined let us generate test model types, encode
      its raw fields, then verify it (which requires the raw fields)
    
    As part of this, this commit also cleans up and fully implements the
    decoding and encoding of such raw data fields, by creating new
    Crypto.Fido2.Model.Binary.{Encoding,Decoding} modules, which contain
    functions for encoding/decoding all binary fields of the model

*   Small model adjustments
    
    When trying to do roundtrip tests for the model encoding, these updates
    were necessary:
    - Make ccdCrossOrigin a required field. It not being set is the same as
      the value False
    - Comment out arcTransports. It was not used, as the webauthn-json library
      doesn't propagate that field

*   Fully implement Arbitrary instances for Model types
*   Add test for model encoding roundtrips