### PR TITLE
Validate errors retrieved during emulated testing

### DIFF
--- a/fido/Crypto/Fido2/Operations/Attestation.hs
+++ b/fido/Crypto/Fido2/Operations/Attestation.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Crypto.Fido2.Operations.Attestation (AttestationError, verifyAttestationResponse, allSupportedFormats) where
+module Crypto.Fido2.Operations.Attestation (AttestationError (..), verifyAttestationResponse, allSupportedFormats) where
 
 import Control.Exception.Base (SomeException (SomeException))
 import Control.Monad (unless)

--- a/fido2.cabal
+++ b/fido2.cabal
@@ -129,7 +129,9 @@ test-suite tests
     Spec.Types,
     Spec.Util,
     Encoding,
+    Emulation,
     Emulation.Client,
+    Emulation.Client.Arbitrary,
     Emulation.Client.PrivateKey,
     Emulation.Authenticator,
     Emulation.Authenticator.Arbitrary

--- a/tests/Emulation.hs
+++ b/tests/Emulation.hs
@@ -1,0 +1,234 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Emulation
+  ( spec,
+  )
+where
+
+import Control.Monad.Except (ExceptT (ExceptT), MonadError, MonadTrans (lift), runExceptT, throwError)
+import qualified Crypto.Fido2.Model as M
+import qualified Crypto.Fido2.Operations.Assertion as Fido2
+import qualified Crypto.Fido2.Operations.Attestation as Fido2
+import qualified Crypto.Fido2.Operations.Common as Fido2
+import qualified Crypto.Fido2.PublicKey as PublicKey
+import Crypto.Hash (hash)
+import qualified Crypto.Random as Random
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Set as Set
+import Data.Text.Encoding (encodeUtf8)
+import Data.Validation (toEither)
+import Emulation.Authenticator
+  ( Authenticator (AuthenticatorNone, aAuthenticatorDataFlags, aConformance, aSignatureCounter),
+    AuthenticatorNonConformingBehaviour (RandomPrivateKey, RandomSignatureData, StaticCounter),
+    AuthenticatorSignatureCounter (Unsupported),
+  )
+import Emulation.Authenticator.Arbitrary ()
+import Emulation.Client (AnnotatedOrigin (AnnotatedOrigin, aoOrigin, aoRpId), UserAgentConformance, UserAgentNonConformingBehaviour (RandomChallenge), clientAssertion, clientAttestation)
+import Emulation.Client.Arbitrary ()
+import Test.Hspec (SpecWith, describe, it, shouldSatisfy)
+import Test.QuickCheck (property)
+
+-- | Custom type to combine the MonadPseudoRandom with the Except monad. We
+-- force the ChaChaDRG to ensure the App type is completely pure, and
+-- evaluating the monad has no side effects.
+newtype App a = App (ExceptT String (Random.MonadPseudoRandom Random.ChaChaDRG) a)
+  deriving newtype (Functor, Applicative, Monad, MonadError String)
+
+instance MonadFail App where
+  fail = throwError
+
+instance Random.MonadRandom App where
+  getRandomBytes n = App $ lift $ Random.getRandomBytes n
+
+runApp :: Integer -> App a -> Either String a
+runApp seed (App except) =
+  let rng = Random.drgNewSeed $ Random.seedFromInteger seed
+   in fst $ Random.withDRG rng $ runExceptT except
+
+-- | Performs attestation to generate a credential, and then uses that
+-- credential to perform assertion.
+register ::
+  (Random.MonadRandom m, MonadFail m) =>
+  AnnotatedOrigin ->
+  UserAgentConformance ->
+  Authenticator ->
+  m (Either (NE.NonEmpty Fido2.AttestationError) Fido2.CredentialEntry, Authenticator, M.PublicKeyCredentialOptions 'M.Create)
+register ao conformance authenticator = do
+  -- Generate new random input
+  assertionChallenge <- M.Challenge <$> Random.getRandomBytes 16
+  userId <- M.UserHandle <$> Random.getRandomBytes 16
+  -- Create dummy user
+  let user =
+        M.PublicKeyCredentialUserEntity
+          { M.pkcueId = userId,
+            M.pkcueDisplayName = M.UserAccountDisplayName "John Doe",
+            M.pkcueName = M.UserAccountName "john-doe"
+          }
+  let options = defaultPkcoc user assertionChallenge
+  -- Perform client Attestation emulation with a fresh authenticator
+  (mPkcCreate, authenticator) <- clientAttestation options ao conformance authenticator
+  -- Verify the result
+  let registerResult =
+        toEither $
+          Fido2.verifyAttestationResponse
+            (aoOrigin ao)
+            (M.RpIdHash . hash . encodeUtf8 . M.unRpId $ aoRpId ao)
+            options
+            mPkcCreate
+  pure (registerResult, authenticator, options)
+
+login ::
+  (Random.MonadRandom m, MonadFail m) =>
+  AnnotatedOrigin ->
+  UserAgentConformance ->
+  Authenticator ->
+  Fido2.CredentialEntry ->
+  m (Either (NE.NonEmpty Fido2.AssertionError) Fido2.SignatureCounterResult)
+login ao conformance authenticator ce@Fido2.CredentialEntry {..} = do
+  attestationChallenge <- M.Challenge <$> Random.getRandomBytes 16
+  let options = defaultPkcog attestationChallenge
+  -- Perform client assertion emulation with the same authenticator, this
+  -- authenticator should now store the created credential
+  (mPkcGet, _) <- clientAssertion options ao conformance authenticator
+  pure
+    . toEither
+    $ Fido2.verifyAssertionResponse
+      (aoOrigin ao)
+      (M.RpIdHash . hash . encodeUtf8 . M.unRpId $ aoRpId ao)
+      (Just ceUserHandle)
+      ce
+      options
+      mPkcGet
+
+spec :: SpecWith ()
+spec =
+  describe "None" $
+    it "succeeds" $
+      property $ \seed authenticator userAgentConformance -> do
+        let annotatedOrigin =
+              AnnotatedOrigin
+                { aoRpId = M.RpId "localhost",
+                  aoOrigin = M.Origin "https://localhost:8080"
+                }
+        -- We are not currently interested in client or authenticator fails, we
+        -- only wish to test our relying party implementation and are thus only
+        -- interested in its errors.
+        let Right (registerResult, authenticator', options) = runApp seed (register annotatedOrigin userAgentConformance authenticator)
+        registerResult `shouldSatisfy` validAttestationResult authenticator userAgentConformance options
+        -- Only if attestation succeeded can we continue with assertion
+        case registerResult of
+          Right credentialEntry -> do
+            let Right loginResult = runApp (seed + 1) (login annotatedOrigin userAgentConformance authenticator' credentialEntry)
+            loginResult `shouldSatisfy` validAssertionResult authenticator userAgentConformance
+          _ -> pure ()
+
+-- | Validates the result of attestation. Ensures that the proper errors are
+-- resulted in if the authenticator exhibits nonconforming behaviour, and
+-- checks if the correct result was given if the authenticator does not exhibit
+-- any nonconforming behaviour.
+validAttestationResult :: Authenticator -> UserAgentConformance -> M.PublicKeyCredentialOptions 'M.Create -> Either (NE.NonEmpty Fido2.AttestationError) Fido2.CredentialEntry -> Bool
+-- A valid result can only happen if we exhibited no non-conforming behaviour
+-- The userHandle must be the one specified by the options
+validAttestationResult _ _ M.PublicKeyCredentialCreationOptions {..} (Right Fido2.CredentialEntry {..}) = ceUserHandle == M.pkcueId pkcocUser
+-- If we did result in errors, we want every error to be validated by some
+-- configuration issue (NOTE: We cannot currently exhibit non conforming
+-- behaviour during attestation)
+validAttestationResult AuthenticatorNone {..} uaConformance _ (Left errors) = all isValidated errors
+  where
+    isValidated :: Fido2.AttestationError -> Bool
+    isValidated (Fido2.AttestationChallengeMismatch _ _) = RandomChallenge `elem` uaConformance
+    isValidated (Fido2.AttestationOriginMismatch _ _) = False
+    isValidated (Fido2.AttestationRpIdHashMismatch _ _) = False
+    -- The User not being present must be a result of the authenticator not checking for a user being present
+    isValidated Fido2.AttestationUserNotPresent = not $ M.adfUserPresent aAuthenticatorDataFlags
+    -- The User not being valided must be a result of the authenticator not validating the user
+    isValidated Fido2.AttestationUserNotVerified = not $ M.adfUserVerified aAuthenticatorDataFlags
+    isValidated (Fido2.AttestationUndesiredPublicKeyAlgorithm _ _) = False
+    isValidated (Fido2.AttestationFormatError _) = False
+
+-- | Validates the result of assertion. Ensures that the proper errors are
+-- resulted in if the authenticator exhibits nonconforming behaviour, and
+-- checks if the correct result was given if the authenticator does not exhibit
+-- any nonconforming behaviour.
+validAssertionResult :: Authenticator -> UserAgentConformance -> Either (NE.NonEmpty Fido2.AssertionError) Fido2.SignatureCounterResult -> Bool
+-- We can only result in a 0 signature counter if the authenticator doesn't
+-- have a counter and is either conforming or only has a static counter
+validAssertionResult AuthenticatorNone {..} _ (Right Fido2.SignatureCounterZero) =
+  aSignatureCounter == Unsupported && (Set.null aConformance || aConformance == Set.singleton StaticCounter)
+-- A valid response must only happen if we have no non-confirming behaviour
+validAssertionResult AuthenticatorNone {..} _ (Right (Fido2.SignatureCounterUpdated _)) = Set.null aConformance
+-- A potentially cloned counter must imply that we only exhibited the static
+-- counter non-conforming behaviour
+validAssertionResult AuthenticatorNone {..} _ (Right Fido2.SignatureCounterPotentiallyCloned) = Set.singleton StaticCounter == aConformance
+-- If we did result in errors, we want every error to be validated by some
+-- non-conforming behaviour or configuration issue
+validAssertionResult AuthenticatorNone {..} uaConformance (Left errors) = all isValidated errors
+  where
+    isValidated :: Fido2.AssertionError -> Bool
+    isValidated (Fido2.AssertionDisallowedCredential _ _) = False
+    isValidated (Fido2.AssertionIdentifiedUserHandleMismatch _ _) = False
+    isValidated (Fido2.AssertionCredentialUserHandleMismatch _ _) = False
+    isValidated Fido2.AssertionCannotVerifyUserHandle = False
+    isValidated (Fido2.AssertionChallengeMismatch _ _) = RandomChallenge `elem` uaConformance
+    isValidated (Fido2.AssertionOriginMismatch _ _) = False
+    isValidated (Fido2.AssertionRpIdHashMismatch _ _) = False
+    -- The User not being present must be a result of the authenticator not checking for a user being present
+    isValidated Fido2.AssertionUserNotPresent = not $ M.adfUserPresent aAuthenticatorDataFlags
+    -- The User not being valided must be a result of the authenticator not validating the user
+    isValidated Fido2.AssertionUserNotVerified = not $ M.adfUserVerified aAuthenticatorDataFlags
+    -- The Signature being invalid can happen when the data was wrong or the wrong private key was used
+    isValidated (Fido2.AssertionInvalidSignature _) = elem RandomSignatureData aConformance || elem RandomPrivateKey aConformance
+
+-- | Create a default set of options for attestation. These options can be modified before using them in the tests
+defaultPkcoc :: M.PublicKeyCredentialUserEntity -> M.Challenge -> M.PublicKeyCredentialOptions 'M.Create
+defaultPkcoc userEntity challenge =
+  M.PublicKeyCredentialCreationOptions
+    { M.pkcocRp = M.PublicKeyCredentialRpEntity {M.pkcreId = Nothing, M.pkcreName = "ACME"},
+      M.pkcocUser = userEntity,
+      M.pkcocChallenge = challenge,
+      -- Empty credentialparameters are not supported.
+      M.pkcocPubKeyCredParams =
+        [ M.PublicKeyCredentialParameters
+            { M.pkcpTyp = M.PublicKeyCredentialTypePublicKey,
+              M.pkcpAlg = PublicKey.COSEAlgorithmIdentifierES256
+            },
+          M.PublicKeyCredentialParameters
+            { M.pkcpTyp = M.PublicKeyCredentialTypePublicKey,
+              M.pkcpAlg = PublicKey.COSEAlgorithmIdentifierES384
+            },
+          M.PublicKeyCredentialParameters
+            { M.pkcpTyp = M.PublicKeyCredentialTypePublicKey,
+              M.pkcpAlg = PublicKey.COSEAlgorithmIdentifierES512
+            },
+          M.PublicKeyCredentialParameters
+            { M.pkcpTyp = M.PublicKeyCredentialTypePublicKey,
+              M.pkcpAlg = PublicKey.COSEAlgorithmIdentifierEdDSA
+            }
+        ],
+      M.pkcocTimeout = Nothing,
+      M.pkcocExcludeCredentials = [],
+      M.pkcocAuthenticatorSelection =
+        Just
+          M.AuthenticatorSelectionCriteria
+            { M.ascAuthenticatorAttachment = Nothing,
+              M.ascResidentKey = M.ResidentKeyRequirementDiscouraged,
+              M.ascUserVerification = M.UserVerificationRequirementPreferred
+            },
+      M.pkcocAttestation = M.AttestationConveyancePreferenceDirect,
+      M.pkcocExtensions = Nothing
+    }
+
+-- | Create a default set of options for assertion. These options can be modified before using them in the tests
+defaultPkcog :: M.Challenge -> M.PublicKeyCredentialOptions 'M.Get
+defaultPkcog challenge =
+  M.PublicKeyCredentialRequestOptions
+    { M.pkcogChallenge = challenge,
+      M.pkcogTimeout = Nothing,
+      M.pkcogRpId = Just "localhost",
+      -- We currently only support client-side discoverable credentials
+      M.pkcogAllowCredentials = [],
+      M.pkcogUserVerification = M.UserVerificationRequirementPreferred,
+      M.pkcogExtensions = Nothing
+    }

--- a/tests/Emulation/Authenticator.hs
+++ b/tests/Emulation/Authenticator.hs
@@ -12,7 +12,6 @@ module Emulation.Authenticator
     Authenticator (..),
     authenticatorMakeCredential,
     authenticatorGetAssertion,
-    isValidAuthenticator,
   )
 where
 
@@ -49,7 +48,7 @@ data AuthenticatorSignatureCounter
   = Unsupported
   | Global M.SignatureCounter
   | PerCredential (Map.Map M.CredentialId M.SignatureCounter)
-  deriving (Show)
+  deriving (Eq, Show)
 
 -- | Non Conforming behaviour the Authenticator should perform. Some behaviours
 -- cannot be performed at the same time. In such cases the superseding or
@@ -76,18 +75,6 @@ data Authenticator = AuthenticatorNone
     aConformance :: Conformance
   }
   deriving (Show)
-
--- | Checks if an authenticator has no nonConforming behaviour and is otherwise
--- capable of being an authenticator
-isValidAuthenticator :: Authenticator -> Bool
-isValidAuthenticator AuthenticatorNone {aSupportedAlgorithms, aConformance, aAuthenticatorDataFlags, aSignatureCounter} =
-  not (Set.null aSupportedAlgorithms) && M.adfUserPresent aAuthenticatorDataFlags
-    -- A static counter has no meaning for an authenticator that doesn't have a
-    -- signature counter, so we accept the StaticCounter behaviour explicitly
-    -- only if the authenticator doesn't have a signature counter.
-    && case aSignatureCounter of
-      Unsupported -> Set.null aConformance || aConformance == Set.singleton StaticCounter
-      _ -> Set.null aConformance
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#sctn-op-make-cred)
 authenticatorMakeCredential ::

--- a/tests/Emulation/Authenticator/Arbitrary.hs
+++ b/tests/Emulation/Authenticator/Arbitrary.hs
@@ -5,13 +5,19 @@ module Emulation.Authenticator.Arbitrary () where
 import qualified Crypto.Fido2.Model as M
 import qualified Crypto.Random as Random
 import qualified Data.Map as Map
+import qualified Data.Set as Set
 import Emulation.Authenticator
   ( Authenticator (AuthenticatorNone),
     AuthenticatorNonConformingBehaviour,
     AuthenticatorSignatureCounter (Global, PerCredential, Unsupported),
   )
 import PublicKeySpec ()
-import Test.QuickCheck (Arbitrary (arbitrary), arbitraryBoundedEnum, oneof)
+import Test.QuickCheck
+  ( Arbitrary (arbitrary),
+    NonEmptyList (getNonEmpty),
+    arbitraryBoundedEnum,
+    oneof,
+  )
 
 instance Arbitrary AuthenticatorNonConformingBehaviour where
   arbitrary = arbitraryBoundedEnum
@@ -44,6 +50,7 @@ instance Arbitrary Authenticator where
       <$> arbitrary
       <*> pure Map.empty
       <*> arbitrary
-      <*> arbitrary
+      -- An authenticator without any supported algorithms is useless to our tests
+      <*> (Set.fromList . getNonEmpty <$> arbitrary)
       <*> arbitrary
       <*> arbitrary

--- a/tests/Emulation/Client.hs
+++ b/tests/Emulation/Client.hs
@@ -7,35 +7,29 @@
 -- | This modules provdes a way to emulate certain client behaviour for testing
 -- purposes. It DOES NOT implement the webauthn specification because there is
 -- no need for it in our tests.
-module Emulation.Client (clientAssertion, spec) where
+module Emulation.Client
+  ( AnnotatedOrigin (..),
+    UserAgentNonConformingBehaviour (..),
+    UserAgentConformance,
+    clientAssertion,
+    clientAttestation,
+  )
+where
 
-import Control.Monad.Except (ExceptT (ExceptT), MonadError, MonadTrans (lift), runExceptT, throwError)
 import Crypto.Fido2.Model (Challenge (Challenge))
 import qualified Crypto.Fido2.Model as M
 import qualified Crypto.Fido2.Model.Binary.Encoding as ME
-import qualified Crypto.Fido2.Operations.Assertion as Fido2
-import qualified Crypto.Fido2.Operations.Attestation as Fido2
-import qualified Crypto.Fido2.Operations.Common as Fido2
-import qualified Crypto.Fido2.PublicKey as PublicKey
 import Crypto.Hash (hash)
-import Crypto.Random (getRandomBytes)
 import qualified Crypto.Random as Random
-import qualified Data.List.NonEmpty as NE
 import Data.Maybe (fromMaybe)
 import qualified Data.Set as Set
-import Data.Text.Encoding (encodeUtf8)
-import Data.Validation (toEither)
 import Emulation.Authenticator
-  ( Authenticator (AuthenticatorNone, aAuthenticatorDataFlags, aConformance, aSignatureCounter),
-    AuthenticatorNonConformingBehaviour (RandomPrivateKey, RandomSignatureData, StaticCounter),
-    AuthenticatorSignatureCounter (Unsupported),
+  ( Authenticator,
     authenticatorGetAssertion,
     authenticatorMakeCredential,
   )
 import Emulation.Authenticator.Arbitrary ()
 import qualified Emulation.Client.PrivateKey as PrivateKey
-import Test.Hspec (SpecWith, describe, it, shouldSatisfy)
-import Test.QuickCheck (property)
 
 -- | The annotated Origin is the origin with the derived (or provided) rpID. It
 -- is a workaround for the fact that we do not derive the rpID from the origin.
@@ -48,27 +42,10 @@ data AnnotatedOrigin = AnnotatedOrigin
 -- | Potential ways the UserAgent could not conform to the specification
 data UserAgentNonConformingBehaviour
   = RandomChallenge
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Show)
 
 -- | The ways in which the UserAgent should not conform to the spec
 type UserAgentConformance = Set.Set UserAgentNonConformingBehaviour
-
--- | Custom type to combine the MonadPseudoRandom with the Except monad. We
--- force the ChaChaDRG to ensure the App type is completely pure, and
--- evaluating the monad has no side effects.
-newtype App a = App (ExceptT String (Random.MonadPseudoRandom Random.ChaChaDRG) a)
-  deriving newtype (Functor, Applicative, Monad, MonadError String)
-
-instance MonadFail App where
-  fail = throwError
-
-instance Random.MonadRandom App where
-  getRandomBytes n = App $ lift $ getRandomBytes n
-
-runApp :: Integer -> App a -> Either String a
-runApp seed (App except) =
-  let rng = Random.drgNewSeed $ Random.seedFromInteger seed
-   in fst $ Random.withDRG rng $ runExceptT except
 
 -- | Emulates the client-side operation for attestation given an authenticator.
 -- MonadRandom is required during the generation of the new credentials, and
@@ -173,190 +150,3 @@ clientAssertion M.PublicKeyCredentialRequestOptions {..} AnnotatedOrigin {..} co
             M.pkcClientExtensionResults = M.AuthenticationExtensionsClientOutputs {}
           }
   pure (response, authenticator')
-
--- | Performs attestation to generate a credential, and then uses that
--- credential to perform assertion.
-register ::
-  (Random.MonadRandom m, MonadFail m) =>
-  AnnotatedOrigin ->
-  UserAgentConformance ->
-  Authenticator ->
-  m (Either (NE.NonEmpty Fido2.AttestationError) Fido2.CredentialEntry, Authenticator, M.PublicKeyCredentialOptions 'M.Create)
-register ao conformance authenticator = do
-  -- Generate new random input
-  assertionChallenge <- M.Challenge <$> Random.getRandomBytes 16
-  userId <- M.UserHandle <$> Random.getRandomBytes 16
-  -- Create dummy user
-  let user =
-        M.PublicKeyCredentialUserEntity
-          { M.pkcueId = userId,
-            M.pkcueDisplayName = M.UserAccountDisplayName "John Doe",
-            M.pkcueName = M.UserAccountName "john-doe"
-          }
-  let options = defaultPkcoc user assertionChallenge
-  -- Perform client Attestation emulation with a fresh authenticator
-  (mPkcCreate, authenticator) <- clientAttestation options ao conformance authenticator
-  -- Verify the result
-  let registerResult =
-        toEither $
-          Fido2.verifyAttestationResponse
-            (aoOrigin ao)
-            (M.RpIdHash . hash . encodeUtf8 . M.unRpId $ aoRpId ao)
-            options
-            mPkcCreate
-  pure (registerResult, authenticator, options)
-
-login ::
-  (Random.MonadRandom m, MonadFail m) =>
-  AnnotatedOrigin ->
-  UserAgentConformance ->
-  Authenticator ->
-  Fido2.CredentialEntry ->
-  m (Either (NE.NonEmpty Fido2.AssertionError) Fido2.SignatureCounterResult)
-login ao conformance authenticator ce@Fido2.CredentialEntry {..} = do
-  attestationChallenge <- M.Challenge <$> Random.getRandomBytes 16
-  let options = defaultPkcog attestationChallenge
-  -- Perform client assertion emulation with the same authenticator, this
-  -- authenticator should now store the created credential
-  (mPkcGet, _) <- clientAssertion options ao conformance authenticator
-  pure
-    . toEither
-    $ Fido2.verifyAssertionResponse
-      (aoOrigin ao)
-      (M.RpIdHash . hash . encodeUtf8 . M.unRpId $ aoRpId ao)
-      (Just ceUserHandle)
-      ce
-      options
-      mPkcGet
-
-spec :: SpecWith ()
-spec =
-  describe "None" $
-    it "succeeds" $
-      property $ \seed authenticator -> do
-        let annotatedOrigin =
-              AnnotatedOrigin
-                { aoRpId = M.RpId "localhost",
-                  aoOrigin = M.Origin "https://localhost:8080"
-                }
-            userAgentConformance = Set.empty
-        -- We are not currently interested in client or authenticator fails, we
-        -- only wish to test our relying party implementation and are thus only
-        -- interested in its errors.
-        let Right (registerResult, authenticator', options) = runApp seed (register annotatedOrigin userAgentConformance authenticator)
-        registerResult `shouldSatisfy` validAttestationResult authenticator options
-        -- Only if attestation succeeded can we continue with assertion
-        case registerResult of
-          Right credentialEntry -> do
-            let Right loginResult = runApp (seed + 1) (login annotatedOrigin userAgentConformance authenticator' credentialEntry)
-            loginResult `shouldSatisfy` validAssertionResult authenticator
-          _ -> pure ()
-
--- | Validates the result of attestation. Ensures that the proper errors are
--- resulted in if the authenticator exhibits nonconforming behaviour, and
--- checks if the correct result was given if the authenticator does not exhibit
--- any nonconforming behaviour.
-validAttestationResult :: Authenticator -> M.PublicKeyCredentialOptions 'M.Create -> Either (NE.NonEmpty Fido2.AttestationError) Fido2.CredentialEntry -> Bool
--- A valid result can only happen if we exhibited no non-conforming behaviour
--- The userHandle must be the one specified by the options
-validAttestationResult _ M.PublicKeyCredentialCreationOptions {..} (Right Fido2.CredentialEntry {..}) = ceUserHandle == M.pkcueId pkcocUser
--- If we did result in errors, we want every error to be validated by some
--- configuration issue (NOTE: We cannot currently exhibit non conforming
--- behaviour during attestation)
-validAttestationResult AuthenticatorNone {..} _ (Left errors) = all isValidated errors
-  where
-    isValidated :: Fido2.AttestationError -> Bool
-    isValidated (Fido2.AttestationChallengeMismatch _ _) = False
-    isValidated (Fido2.AttestationOriginMismatch _ _) = False
-    isValidated (Fido2.AttestationRpIdHashMismatch _ _) = False
-    -- The User not being present must be a result of the authenticator not checking for a user being present
-    isValidated Fido2.AttestationUserNotPresent = not $ M.adfUserPresent aAuthenticatorDataFlags
-    -- The User not being valided must be a result of the authenticator not validating the user
-    isValidated Fido2.AttestationUserNotVerified = not $ M.adfUserVerified aAuthenticatorDataFlags
-    isValidated (Fido2.AttestationUndesiredPublicKeyAlgorithm _ _) = False
-    isValidated (Fido2.AttestationFormatError _) = False
-
--- | Validates the result of assertion. Ensures that the proper errors are
--- resulted in if the authenticator exhibits nonconforming behaviour, and
--- checks if the correct result was given if the authenticator does not exhibit
--- any nonconforming behaviour.
-validAssertionResult :: Authenticator -> Either (NE.NonEmpty Fido2.AssertionError) Fido2.SignatureCounterResult -> Bool
--- We can only result in a 0 signature counter if the authenticator doesn't
--- have a counter and is either conforming or only has a static counter
-validAssertionResult AuthenticatorNone {..} (Right Fido2.SignatureCounterZero) =
-  aSignatureCounter == Unsupported && (Set.null aConformance || aConformance == Set.singleton StaticCounter)
--- A valid response must only happen if we have no non-confirming behaviour
-validAssertionResult AuthenticatorNone {..} (Right (Fido2.SignatureCounterUpdated _)) = Set.null aConformance
--- A potentially cloned counter must imply that we only exhibited the static
--- counter non-conforming behaviour
-validAssertionResult AuthenticatorNone {..} (Right Fido2.SignatureCounterPotentiallyCloned) = Set.singleton StaticCounter == aConformance
--- If we did result in errors, we want every error to be validated by some
--- non-conforming behaviour or configuration issue
-validAssertionResult AuthenticatorNone {..} (Left errors) = all isValidated errors
-  where
-    isValidated :: Fido2.AssertionError -> Bool
-    isValidated (Fido2.AssertionDisallowedCredential _ _) = False
-    isValidated (Fido2.AssertionIdentifiedUserHandleMismatch _ _) = False
-    isValidated (Fido2.AssertionCredentialUserHandleMismatch _ _) = False
-    isValidated Fido2.AssertionCannotVerifyUserHandle = False
-    isValidated (Fido2.AssertionChallengeMismatch _ _) = False
-    isValidated (Fido2.AssertionOriginMismatch _ _) = False
-    isValidated (Fido2.AssertionRpIdHashMismatch _ _) = False
-    -- The User not being present must be a result of the authenticator not checking for a user being present
-    isValidated Fido2.AssertionUserNotPresent = not $ M.adfUserPresent aAuthenticatorDataFlags
-    -- The User not being valided must be a result of the authenticator not validating the user
-    isValidated Fido2.AssertionUserNotVerified = not $ M.adfUserVerified aAuthenticatorDataFlags
-    -- The Signature being invalid can happen when the data was wrong or the wrong private key was used
-    isValidated (Fido2.AssertionInvalidSignature _) = elem RandomSignatureData aConformance || elem RandomPrivateKey aConformance
-
--- | Create a default set of options for attestation. These options can be modified before using them in the tests
-defaultPkcoc :: M.PublicKeyCredentialUserEntity -> M.Challenge -> M.PublicKeyCredentialOptions 'M.Create
-defaultPkcoc userEntity challenge =
-  M.PublicKeyCredentialCreationOptions
-    { M.pkcocRp = M.PublicKeyCredentialRpEntity {M.pkcreId = Nothing, M.pkcreName = "ACME"},
-      M.pkcocUser = userEntity,
-      M.pkcocChallenge = challenge,
-      -- Empty credentialparameters are not supported.
-      M.pkcocPubKeyCredParams =
-        [ M.PublicKeyCredentialParameters
-            { M.pkcpTyp = M.PublicKeyCredentialTypePublicKey,
-              M.pkcpAlg = PublicKey.COSEAlgorithmIdentifierES256
-            },
-          M.PublicKeyCredentialParameters
-            { M.pkcpTyp = M.PublicKeyCredentialTypePublicKey,
-              M.pkcpAlg = PublicKey.COSEAlgorithmIdentifierES384
-            },
-          M.PublicKeyCredentialParameters
-            { M.pkcpTyp = M.PublicKeyCredentialTypePublicKey,
-              M.pkcpAlg = PublicKey.COSEAlgorithmIdentifierES512
-            },
-          M.PublicKeyCredentialParameters
-            { M.pkcpTyp = M.PublicKeyCredentialTypePublicKey,
-              M.pkcpAlg = PublicKey.COSEAlgorithmIdentifierEdDSA
-            }
-        ],
-      M.pkcocTimeout = Nothing,
-      M.pkcocExcludeCredentials = [],
-      M.pkcocAuthenticatorSelection =
-        Just
-          M.AuthenticatorSelectionCriteria
-            { M.ascAuthenticatorAttachment = Nothing,
-              M.ascResidentKey = M.ResidentKeyRequirementDiscouraged,
-              M.ascUserVerification = M.UserVerificationRequirementPreferred
-            },
-      M.pkcocAttestation = M.AttestationConveyancePreferenceDirect,
-      M.pkcocExtensions = Nothing
-    }
-
--- | Create a default set of options for assertion. These options can be modified before using them in the tests
-defaultPkcog :: M.Challenge -> M.PublicKeyCredentialOptions 'M.Get
-defaultPkcog challenge =
-  M.PublicKeyCredentialRequestOptions
-    { M.pkcogChallenge = challenge,
-      M.pkcogTimeout = Nothing,
-      M.pkcogRpId = Just "localhost",
-      -- We currently only support client-side discoverable credentials
-      M.pkcogAllowCredentials = [],
-      M.pkcogUserVerification = M.UserVerificationRequirementPreferred,
-      M.pkcogExtensions = Nothing
-    }

--- a/tests/Emulation/Client/Arbitrary.hs
+++ b/tests/Emulation/Client/Arbitrary.hs
@@ -1,0 +1,15 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Emulation.Client.Arbitrary () where
+
+import Emulation.Client
+  ( UserAgentNonConformingBehaviour (RandomChallenge),
+  )
+import PublicKeySpec ()
+import Test.QuickCheck
+  ( Arbitrary (arbitrary),
+  )
+import Test.QuickCheck.Gen (elements)
+
+instance Arbitrary UserAgentNonConformingBehaviour where
+  arbitrary = elements [RandomChallenge]

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -24,7 +24,7 @@ import Data.Either (isRight)
 import Data.Foldable (for_)
 import Data.List.NonEmpty (NonEmpty)
 import Data.Validation (toEither)
-import qualified Emulation.Client as Client
+import qualified Emulation
 import qualified Encoding
 import GHC.Stack (HasCallStack)
 import qualified MetadataSpec
@@ -74,8 +74,8 @@ main = Hspec.hspec $ do
     "Metadata"
     MetadataSpec.spec
   describe
-    "Client Emulation"
-    Client.spec
+    "Emulation"
+    Emulation.spec
   describe
     "Encoding"
     Encoding.spec


### PR DESCRIPTION
Checks if all errors we get during emulation testing can be explained by the configuration of the authenticator.